### PR TITLE
fix(server): support multiple CORS origins

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -22,4 +22,5 @@ R2_BUCKET_NAME =
 # Public base URL for the bucket (custom domain or the r2.dev dev URL)
 R2_PUBLIC_URL =
 
+# Comma-separated list of allowed origins (e.g. custom domain + Railway-generated domain)
 CLIENT_ORIGIN =

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -4,20 +4,11 @@ import { StatusCodes } from "http-status-codes";
 import cookieParser from "cookie-parser";
 import express, { json } from "express";
 import { createServer } from "http";
-// import fs from "fs";
-// import path from "path";
-// import { fileURLToPath } from "url";
 
 import apiRouter from "./api/routes/index.js";
 import setupSocket from "./socket/index.js";
 import embeddingProvider from "./config/embedding-provider.js";
 import { handleApiError } from "./middlewares/error-middleware.js";
-
-// const __filename = fileURLToPath(import.meta.url);
-// const __dirname = path.dirname(__filename);
-
-// const certPath = path.join(__dirname, "../certificates", "localhost.pem");
-// const keyPath = path.join(__dirname, "../certificates", "localhost-key.pem");
 
 /**
  * Starts the server with Express and HTTP.
@@ -26,13 +17,8 @@ import { handleApiError } from "./middlewares/error-middleware.js";
  * @description Initializes an Express application, sets up an HTTP server, and configures routes.
  */
 const startServer = () => {
-  // const httpsOptions = {
-  //   key: fs.readFileSync(keyPath),
-  //   cert: fs.readFileSync(certPath)
-  // };
   const app = express();
   const server = createServer(app);
-  // const server = createServer(httpsOptions, app);
 
   setupSocket(server);
 
@@ -41,7 +27,7 @@ const startServer = () => {
   app.use(cookieParser());
   app.use(
     cors({
-      origin: [process.env.CLIENT_ORIGIN, "http://localhost:3000"],
+      origin: [...process.env.CLIENT_ORIGIN.split(","), "http://localhost:3000"],
       credentials: true
     })
   );

--- a/server/src/socket/index.js
+++ b/server/src/socket/index.js
@@ -10,7 +10,7 @@ let ioInstance = null;
 const setupSocket = (server) => {
   const io = new Server(server, {
     cors: {
-      origin: [process.env.CLIENT_ORIGIN, "https://localhost:3000"],
+      origin: [...process.env.CLIENT_ORIGIN.split(","), "https://localhost:3000"],
       methods: ["GET", "POST"],
       credentials: true
     }


### PR DESCRIPTION
## Summary
- CLIENT_ORIGIN was a single origin string; adding a custom domain for the client alongside its Railway-generated domain broke CORS for whichever wasn't configured.
- Both server.js (Express CORS) and socket/index.js (Socket.IO CORS) now split CLIENT_ORIGIN on commas into an array of allowed origins.
- .env.example comment updated to document the comma-separated format.

## Test plan
- [ ] Set CLIENT_ORIGIN to a comma-separated list of both domains on Railway
- [ ] Verify register/login from the custom domain no longer hits a CORS error
- [ ] Verify the Railway-generated client domain still works too