### PR TITLE
fix(auth): scope cookies to shared parent domain

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -24,3 +24,6 @@ R2_PUBLIC_URL =
 
 # Comma-separated list of allowed origins (e.g. custom domain + Railway-generated domain)
 CLIENT_ORIGIN =
+# Shared parent domain for auth cookies so they work across subdomains
+# (e.g. ".nguyenhuyhoang.work" if client and API are both subdomains of it). Leave empty for local dev.
+COOKIE_DOMAIN =

--- a/server/src/api/controllers/auth-controller.js
+++ b/server/src/api/controllers/auth-controller.js
@@ -5,6 +5,9 @@ import authService from "../services/auth-service.js";
 import jwtProvider from "../../config/jwt-provider.js";
 import ApiError from "../../utils/api-error.js";
 
+const isProd = process.env.NODE_ENV === "production";
+const cookieDomain = process.env.COOKIE_DOMAIN || undefined;
+
 const register = async (req, res, next) => {
   try {
     const user = await authService.register(req.body);
@@ -42,8 +45,9 @@ const login = async (req, res, next) => {
     res.cookie("access_token", accessToken, {
       maxAge: ms("1h"),
       httpOnly: true,
-      secure: true,
-      sameSite: "none"
+      secure: isProd,
+      sameSite: isProd ? "none" : "lax",
+      domain: cookieDomain
     });
 
     if (remember) {
@@ -57,7 +61,8 @@ const login = async (req, res, next) => {
         maxAge: ms("7 days"),
         httpOnly: true,
         secure: true,
-        sameSite: "none"
+        sameSite: "none",
+        domain: cookieDomain
       });
     }
 
@@ -113,8 +118,9 @@ const refreshSession = async (req, res, next) => {
     res.cookie("access_token", accessToken, {
       maxAge: ms("1h"),
       httpOnly: true,
-      secure: true,
-      sameSite: "none"
+      secure: isProd,
+      sameSite: isProd ? "none" : "lax",
+      domain: cookieDomain
     });
 
     res.status(StatusCodes.OK).json({
@@ -128,8 +134,8 @@ const refreshSession = async (req, res, next) => {
 
 const logout = async (req, res, next) => {
   try {
-    res.clearCookie("access_token");
-    res.clearCookie("refresh_token");
+    res.clearCookie("access_token", { domain: cookieDomain });
+    res.clearCookie("refresh_token", { domain: cookieDomain });
 
     const userId = await authService.logout(req.user.id);
 


### PR DESCRIPTION
## Summary
- access_token/refresh_token cookies had no Domain attribute, defaulting to the exact API host. Since client and API are sibling subdomains, the browser never sent the cookie back to the client's domain, so middleware.js's session check always failed right after a successful login.
- Added COOKIE_DOMAIN env var (e.g. ".nguyenhuyhoang.work") to scope cookies to the shared parent domain across both subdomains.

## Test plan
- [ ] Set COOKIE_DOMAIN on the server service in Railway
- [ ] Log in and confirm redirect to /app succeeds
- [ ] Confirm navigating directly to /app while logged in doesn't bounce to /auth/login