### PR TITLE
fix(auth): logout clearCookie attributes + NODE_ENV doc

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,5 +1,7 @@
 APP_PORT =
 APP_HOST =
+# Set to "production" on deployed environments so auth cookies get secure/SameSite=None
+NODE_ENV =
 
 # Do not expose your database credentials to the browser
 # Railway Postgres connection string (Postgres addon with the pgvector extension)

--- a/server/src/api/controllers/auth-controller.js
+++ b/server/src/api/controllers/auth-controller.js
@@ -134,8 +134,16 @@ const refreshSession = async (req, res, next) => {
 
 const logout = async (req, res, next) => {
   try {
-    res.clearCookie("access_token", { domain: cookieDomain });
-    res.clearCookie("refresh_token", { domain: cookieDomain });
+    res.clearCookie("access_token", {
+      secure: isProd,
+      sameSite: isProd ? "none" : "lax",
+      domain: cookieDomain
+    });
+    res.clearCookie("refresh_token", {
+      secure: true,
+      sameSite: "none",
+      domain: cookieDomain
+    });
 
     const userId = await authService.logout(req.user.id);
 


### PR DESCRIPTION
## Summary
- Security review flagged: logout's clearCookie only passed `domain`, not the `secure`/`sameSite` attributes used when the cookie was set — browsers can fail to match it as the same cookie, so logout could silently leave the session cookie intact.
- Security review also flagged: the isProd-gated secure/SameSite=None cookie settings silently downgrade to insecure/Lax whenever NODE_ENV isn't "production", which was the case on the deployed server (regression from the previous always-secure behavior). Documented NODE_ENV in .env.example; setting it on Railway separately.

## Test plan
- [ ] Log in, then log out, and confirm the access_token/refresh_token cookies are actually removed (DevTools Application > Cookies)
- [ ] Confirm cookies are Secure + SameSite=None in production after NODE_ENV=production is set