### PR TITLE
feat(realtime): sync task/project/team across clients, add conflict detection

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -37,6 +37,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.1.8",
+    "@tanstack/react-query": "^5",
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/client/src/app/(app)/layout.jsx
+++ b/client/src/app/(app)/layout.jsx
@@ -2,6 +2,7 @@ import { cookies } from "next/headers";
 
 import AppSidebar from "@/components/app/app-sidebar";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
+import { QueryProvider } from "@/providers/query-provider";
 import { SessionProvider } from "@/hooks/use-session";
 import { SocketProvider } from "@/hooks/use-socket";
 import { SearchProvider } from "@/hooks/use-search";
@@ -17,28 +18,30 @@ export default async function RootLayout({ children }) {
   const defaultOpen = cookieStore.get("sidebar_state")?.value === "true";
 
   return (
-    <SessionProvider>
-      <SocketProvider>
-        <NotificationProvider>
-          <TeamProvider>
-            <ProjectProvider>
-              <TaskProvider>
-                <ChatProvider>
-                  <SidebarProvider defaultOpen={defaultOpen}>
-                    <SearchProvider>
-                      <AppSidebar variant="inset" />
-                      <SidebarInset>
-                        <main className="flex-1 min-h-[95dvh] bg-prussian-blue">{children}</main>
-                      </SidebarInset>
-                      <Toaster position="top-right" />
-                    </SearchProvider>
-                  </SidebarProvider>
-                </ChatProvider>
-              </TaskProvider>
-            </ProjectProvider>
-          </TeamProvider>
-        </NotificationProvider>
-      </SocketProvider>
-    </SessionProvider>
+    <QueryProvider>
+      <SessionProvider>
+        <SocketProvider>
+          <NotificationProvider>
+            <TeamProvider>
+              <ProjectProvider>
+                <TaskProvider>
+                  <ChatProvider>
+                    <SidebarProvider defaultOpen={defaultOpen}>
+                      <SearchProvider>
+                        <AppSidebar variant="inset" />
+                        <SidebarInset>
+                          <main className="flex-1 min-h-[95dvh] bg-prussian-blue">{children}</main>
+                        </SidebarInset>
+                        <Toaster position="top-right" />
+                      </SearchProvider>
+                    </SidebarProvider>
+                  </ChatProvider>
+                </TaskProvider>
+              </ProjectProvider>
+            </TeamProvider>
+          </NotificationProvider>
+        </SocketProvider>
+      </SessionProvider>
+    </QueryProvider>
   );
 }

--- a/client/src/hooks/use-project.js
+++ b/client/src/hooks/use-project.js
@@ -1,6 +1,8 @@
 "use client";
 
 import { useCallback, useState, useEffect, createContext, useContext } from "react";
+import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 import {
   createProject,
@@ -13,6 +15,7 @@ import {
   getProjectsInTeamOfUser
 } from "@/actions/project-actions";
 import { useTeam } from "@/hooks/use-team";
+import { useSocket } from "@/hooks/use-socket";
 
 const ProjectContext = createContext();
 
@@ -22,37 +25,21 @@ export function useProject() {
 
 export function ProjectProvider({ children }) {
   const { selectedTeam } = useTeam();
-  const [projects, setProjects] = useState({});
-  const [selectedProject, setSelectedProject] = useState(null);
-  const [projectMembers, setProjectMembers] = useState([]);
-  const [loading, setLoading] = useState(false);
+  const { socket, connected } = useSocket();
+  const queryClient = useQueryClient();
+
   const [error, setError] = useState(null);
+  const [requestedTeamIds, setRequestedTeamIds] = useState([]);
+  const [selectedProjectId, setSelectedProjectId] = useState(null);
 
-  const fetchProjects = useCallback(async (teamId) => {
-    if (!teamId) return;
-
-    try {
-      setLoading(true);
-      const data = await getProjectsInTeamOfUser(teamId);
-      setProjects((prev) => ({ ...prev, [teamId]: data.projects }));
-    } catch (err) {
-      setError(err);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  const fetchProjectMembers = useCallback(async (projectId) => {
-    try {
-      setLoading(true);
-      const data = await getMembersOfProject(projectId);
-      setProjectMembers(data.members);
-    } catch (err) {
-      setError(err);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const fetchProjects = useCallback(
+    (teamId) => {
+      if (!teamId) return;
+      setRequestedTeamIds((prev) => (prev.includes(teamId) ? prev : [...prev, teamId]));
+      return queryClient.invalidateQueries({ queryKey: ["projects", teamId] });
+    },
+    [queryClient]
+  );
 
   useEffect(() => {
     if (selectedTeam) {
@@ -60,17 +47,89 @@ export function ProjectProvider({ children }) {
     }
   }, [selectedTeam, fetchProjects]);
 
+  const projectQueries = useQueries({
+    queries: requestedTeamIds.map((teamId) => ({
+      queryKey: ["projects", teamId],
+      queryFn: async () => {
+        const data = await getProjectsInTeamOfUser(teamId);
+        return data.projects;
+      },
+      enabled: !!teamId
+    }))
+  });
+
+  // Keep the same lazily-populated { [teamId]: Project[] } shape existing
+  // components rely on (some index by team id, some flatten with Object.values).
+  const projects = requestedTeamIds.reduce((acc, teamId, idx) => {
+    acc[teamId] = projectQueries[idx]?.data ?? [];
+    return acc;
+  }, {});
+
+  const selectedProject =
+    (projects[selectedTeam?.id] || []).find((p) => p.id === selectedProjectId) ?? null;
+
+  const setSelectedProject = useCallback((project) => {
+    setSelectedProjectId(project?.id ?? null);
+  }, []);
+
+  const projectMembersQuery = useQuery({
+    queryKey: ["project-members", selectedProject?.id],
+    queryFn: async () => {
+      const data = await getMembersOfProject(selectedProject.id);
+      return data.members;
+    },
+    enabled: !!selectedProject?.id
+  });
+  const projectMembers = projectMembersQuery.data ?? [];
+
+  const fetchProjectMembers = useCallback(
+    (projectId) => {
+      if (!projectId) return;
+      return queryClient.invalidateQueries({ queryKey: ["project-members", projectId] });
+    },
+    [queryClient]
+  );
+
+  const loading = projectQueries.some((q) => q.isLoading) || projectMembersQuery.isLoading;
+
+  // Real-time sync: another member's project create/update/delete/membership change
   useEffect(() => {
-    if (selectedProject) {
-      fetchProjectMembers(selectedProject.id);
-    }
-  }, [selectedProject, fetchProjectMembers]);
+    if (!socket || !connected) return;
+
+    const handleProjectChanged = (payload) => {
+      if (payload?.team_id) {
+        queryClient.invalidateQueries({ queryKey: ["projects", payload.team_id] });
+      }
+      if (payload?.project_id) {
+        queryClient.invalidateQueries({ queryKey: ["project-members", payload.project_id] });
+      }
+    };
+
+    socket.on("project_changed", handleProjectChanged);
+
+    return () => {
+      socket.off("project_changed", handleProjectChanged);
+    };
+  }, [socket, connected, queryClient]);
+
+  const handleConflict = useCallback(
+    async (err, invalidateKeys) => {
+      if (err?.status === 409) {
+        toast.error(err.message || "This was updated by someone else. Refreshing...");
+        await Promise.all(
+          invalidateKeys.map((queryKey) => queryClient.invalidateQueries({ queryKey }))
+        );
+        return true;
+      }
+      return false;
+    },
+    [queryClient]
+  );
 
   // Project actions
   const handleCreateProject = useCallback(
     async (projectData) => {
       try {
-        setLoading(true);
         const newProject = await createProject(projectData);
         await fetchProjects(selectedTeam.id);
         setSelectedProject(newProject);
@@ -78,40 +137,36 @@ export function ProjectProvider({ children }) {
       } catch (err) {
         setError(err);
         throw err;
-      } finally {
-        setLoading(false);
       }
     },
-    [fetchProjects, selectedTeam]
+    [fetchProjects, selectedTeam, setSelectedProject]
   );
 
   const handleUpdateProject = useCallback(
     async (projectId, updates) => {
       try {
-        setLoading(true);
-        await updateProject(projectId, updates);
+        const currentProject = (projects[selectedTeam?.id] || []).find((p) => p.id === projectId);
+        await updateProject(projectId, { ...updates, updated_at: currentProject?.updated_at });
         await fetchProjects(selectedTeam.id);
       } catch (err) {
-        setError(err);
-        throw err;
-      } finally {
-        setLoading(false);
+        const isConflict = await handleConflict(err, [["projects", selectedTeam?.id]]);
+        if (!isConflict) {
+          setError(err);
+          throw err;
+        }
       }
     },
-    [fetchProjects, selectedTeam]
+    [fetchProjects, selectedTeam, projects, handleConflict]
   );
 
   const handleDeleteProject = useCallback(
     async (projectId) => {
       try {
-        setLoading(true);
         await deleteProject(projectId);
         await fetchProjects(selectedTeam.id);
       } catch (err) {
         setError(err);
         throw err;
-      } finally {
-        setLoading(false);
       }
     },
     [fetchProjects, selectedTeam]
@@ -120,14 +175,11 @@ export function ProjectProvider({ children }) {
   const handleAddProjectMembers = useCallback(
     async (projectId, data) => {
       try {
-        setLoading(true);
         await addMembersToProject(projectId, data);
         await fetchProjectMembers(projectId);
       } catch (err) {
         setError(err);
         throw err;
-      } finally {
-        setLoading(false);
       }
     },
     [fetchProjectMembers]
@@ -136,14 +188,11 @@ export function ProjectProvider({ children }) {
   const handleRemoveProjectMembers = useCallback(
     async (projectId, data) => {
       try {
-        setLoading(true);
         await removeMembersFromProject(projectId, data);
         await fetchProjectMembers(projectId);
       } catch (err) {
         setError(err);
         throw err;
-      } finally {
-        setLoading(false);
       }
     },
     [fetchProjectMembers]
@@ -152,14 +201,11 @@ export function ProjectProvider({ children }) {
   const handleUpdateProjectRoleOfMember = useCallback(
     async (projectId, data) => {
       try {
-        setLoading(true);
         await updateProjectRoleOfMember(projectId, data);
         await fetchProjectMembers(projectId);
       } catch (err) {
         setError(err);
         throw err;
-      } finally {
-        setLoading(false);
       }
     },
     [fetchProjectMembers]

--- a/client/src/hooks/use-task.js
+++ b/client/src/hooks/use-task.js
@@ -1,6 +1,8 @@
 "use client";
 
-import { createContext, useContext, useState, useEffect, useCallback } from "react";
+import { createContext, useContext, useEffect, useCallback, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 import {
   getTasksOfProject,
@@ -10,6 +12,7 @@ import {
   deleteTask
 } from "@/actions/task-actions";
 import { useProject } from "@/hooks/use-project";
+import { useSocket } from "@/hooks/use-socket";
 
 const TaskContext = createContext();
 
@@ -19,62 +22,85 @@ export function useTask() {
 
 export function TaskProvider({ children }) {
   const { selectedProject, projectMembers } = useProject();
+  const { socket, connected } = useSocket();
+  const queryClient = useQueryClient();
 
-  const [tasks, setTasks] = useState([]);
-  const [myAssignedTasks, setMyAssignedTasks] = useState([]);
-
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-
-  // Fetch tasks
-  const fetchTasks = useCallback(async () => {
-    if (!selectedProject) return;
-
-    try {
-      setLoading(true);
-      setError(null);
+  const tasksQuery = useQuery({
+    queryKey: ["tasks", selectedProject?.id],
+    queryFn: async () => {
       const data = await getTasksOfProject(selectedProject.id);
-      setTasks(data.tasks);
-    } catch (err) {
-      setError(err);
-    } finally {
-      setLoading(false);
-    }
-  }, [selectedProject]);
+      return data.tasks;
+    },
+    enabled: !!selectedProject?.id
+  });
+  const tasks = tasksQuery.data ?? [];
 
-  const fetchMyAssignedTasks = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
+  const myAssignedTasksQuery = useQuery({
+    queryKey: ["my-assigned-tasks"],
+    queryFn: async () => {
       const data = await getMyAssignedTasks();
-      setMyAssignedTasks(data.tasks);
-    } catch (err) {
-      setError(err);
-    } finally {
-      setLoading(false);
+      return data.tasks;
     }
-  }, []);
+  });
+  const myAssignedTasks = myAssignedTasksQuery.data ?? [];
 
-  // Initial fetch
-  useEffect(() => {
-    fetchTasks();
-  }, [fetchTasks]);
+  const [mutationError, setMutationError] = useState(null);
 
-  // Initial fetch
+  const loading = tasksQuery.isLoading || myAssignedTasksQuery.isLoading;
+  const error = tasksQuery.error || myAssignedTasksQuery.error || mutationError;
+
+  const fetchMyAssignedTasks = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: ["my-assigned-tasks"] }),
+    [queryClient]
+  );
+
+  // Real-time sync: another member created/updated/deleted/reordered a task
   useEffect(() => {
-    fetchMyAssignedTasks();
-  }, [tasks, fetchMyAssignedTasks]);
+    if (!socket || !connected) return;
+
+    const handleTaskChanged = (payload) => {
+      if (payload?.project_id) {
+        queryClient.invalidateQueries({ queryKey: ["tasks", payload.project_id] });
+      }
+      queryClient.invalidateQueries({ queryKey: ["my-assigned-tasks"] });
+    };
+
+    socket.on("task_changed", handleTaskChanged);
+
+    return () => {
+      socket.off("task_changed", handleTaskChanged);
+    };
+  }, [socket, connected, queryClient]);
+
+  const handleConflict = useCallback(
+    async (err) => {
+      if (err?.status === 409) {
+        toast.error(err.message || "This task was updated by someone else. Refreshing...");
+        await queryClient.invalidateQueries({ queryKey: ["tasks", selectedProject?.id] });
+        return true;
+      }
+      return false;
+    },
+    [queryClient, selectedProject]
+  );
 
   // Create a new task
-  const handleCreateTask = useCallback(async (taskData) => {
-    try {
-      const newTaskData = await createTask(taskData);
+  const handleCreateTask = useCallback(
+    async (taskData) => {
+      try {
+        const newTaskData = await createTask(taskData);
 
-      setTasks((prev) => [...prev, newTaskData.task]);
-    } catch (err) {
-      setError(err);
-    }
-  }, []);
+        queryClient.setQueryData(["tasks", selectedProject?.id], (prev = []) => [
+          ...prev,
+          newTaskData.task
+        ]);
+        await queryClient.invalidateQueries({ queryKey: ["my-assigned-tasks"] });
+      } catch (err) {
+        setMutationError(err);
+      }
+    },
+    [queryClient, selectedProject]
+  );
 
   // Update a task
   const handleUpdateTask = useCallback(
@@ -112,7 +138,7 @@ export function TaskProvider({ children }) {
         }
 
         // Optimistic update: always update the task with new fields
-        setTasks((prev) =>
+        queryClient.setQueryData(["tasks", selectedProject?.id], (prev = []) =>
           prev.map((task) =>
             task.id === taskId
               ? {
@@ -125,33 +151,49 @@ export function TaskProvider({ children }) {
           )
         );
 
-        await updateTask(taskId, updates);
+        await updateTask(taskId, { ...updates, updated_at: currentTask?.updated_at });
+        await queryClient.invalidateQueries({ queryKey: ["my-assigned-tasks"] });
       } catch (err) {
-        setError(err);
+        const isConflict = await handleConflict(err);
+        if (!isConflict) setMutationError(err);
       }
     },
-    [tasks, projectMembers]
+    [tasks, projectMembers, queryClient, selectedProject, handleConflict]
   );
 
   // Delete a task
-  const handleDeleteTask = useCallback(async (taskId) => {
-    try {
-      setTasks((prev) => prev.filter((task) => task.id !== taskId));
+  const handleDeleteTask = useCallback(
+    async (taskId) => {
+      try {
+        queryClient.setQueryData(["tasks", selectedProject?.id], (prev = []) =>
+          prev.filter((task) => task.id !== taskId)
+        );
 
-      await deleteTask(taskId);
-    } catch (err) {
-      setError(err);
-    }
-  }, []);
+        await deleteTask(taskId);
+        await queryClient.invalidateQueries({ queryKey: ["my-assigned-tasks"] });
+      } catch (err) {
+        setMutationError(err);
+        await queryClient.invalidateQueries({ queryKey: ["tasks", selectedProject?.id] });
+      }
+    },
+    [queryClient, selectedProject]
+  );
 
   // Reorder tasks (for drag and drop in list view)
-  const handleReorderTask = useCallback(async (taskId, newPosition) => {
-    try {
-      await updateTask(taskId, { position: newPosition });
-    } catch (err) {
-      setError(err);
-    }
-  }, []);
+  const handleReorderTask = useCallback(
+    async (taskId, newPosition) => {
+      try {
+        const currentTask = tasks.find((task) => task.id === taskId);
+
+        await updateTask(taskId, { position: newPosition, updated_at: currentTask?.updated_at });
+        await queryClient.invalidateQueries({ queryKey: ["tasks", selectedProject?.id] });
+      } catch (err) {
+        const isConflict = await handleConflict(err);
+        if (!isConflict) setMutationError(err);
+      }
+    },
+    [tasks, queryClient, selectedProject, handleConflict]
+  );
 
   const contextValue = {
     tasks,

--- a/client/src/hooks/use-team.js
+++ b/client/src/hooks/use-team.js
@@ -1,6 +1,8 @@
 "use client";
 
 import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 import {
   createTeam,
@@ -18,6 +20,7 @@ import {
 } from "@/actions/team-actions";
 
 import { useSession } from "@/hooks/use-session";
+import { useSocket } from "@/hooks/use-socket";
 
 const TeamContext = createContext();
 
@@ -27,215 +30,205 @@ export function useTeam() {
 
 export function TeamProvider({ children }) {
   const { user } = useSession();
-  const [loading, setLoading] = useState(true);
+  const { socket, connected } = useSocket();
+  const queryClient = useQueryClient();
+
   const [error, setError] = useState(null);
+  const [selectedTeamId, setSelectedTeamId] = useState(null);
 
-  // Team state
-  const [teams, setTeams] = useState([]);
-  const [selectedTeam, setSelectedTeam] = useState(null);
-  const [teamMembers, setTeamMembers] = useState([]);
-  const [teamJoinRequests, setTeamJoinRequests] = useState([]);
-
-  // Fetch teams
-  const fetchTeams = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
+  const teamsQuery = useQuery({
+    queryKey: ["teams"],
+    queryFn: async () => {
       const data = await getTeamsOfUser();
-      setTeams(data.teams);
-      if (data.teams.length > 0 && !selectedTeam) {
-        setSelectedTeam(data.teams[0]);
-      }
-    } catch (err) {
-      setError(err);
-    } finally {
-      setLoading(false);
-    }
-  }, [user]);
-
-  // Fetch team members
-  const fetchTeamMembers = useCallback(
-    async (teamId) => {
-      try {
-        setLoading(true);
-        setError(null);
-        const data = await getMembersOfTeam(teamId);
-        setTeamMembers(data.members);
-      } catch (err) {
-        setError(err);
-      } finally {
-        setLoading(false);
-      }
+      return data.teams;
     },
-    [user]
-  );
+    enabled: !!user
+  });
 
-  // Fetch team requests
-  const fetchTeamJoinRequests = useCallback(
-    async (teamId) => {
-      try {
-        setLoading(true);
-        setError(null);
-        const data = await getJoinRequestsOfTeam(teamId);
-        setTeamJoinRequests(data.requests);
-      } catch (err) {
-        setError(err);
-      } finally {
-        setLoading(false);
-      }
-    },
-    [user]
-  );
+  const teams = teamsQuery.data ?? [];
+  // Re-derive from the cached list on every render so an edit to the selected
+  // team (rename, etc.) shows up immediately without a manual re-select.
+  const selectedTeam = teams.find((t) => t.id === selectedTeamId) ?? null;
 
-  // Initial data fetch
+  const setSelectedTeam = useCallback((team) => {
+    setSelectedTeamId(team?.id ?? null);
+  }, []);
+
+  // Auto-select the first team once teams load, if none selected yet
   useEffect(() => {
-    fetchTeams();
-  }, [fetchTeams]);
-
-  // Fetch team members and requests when team changes
-  useEffect(() => {
-    if (selectedTeam) {
-      fetchTeamMembers(selectedTeam.id);
-      fetchTeamJoinRequests(selectedTeam.id);
+    if (teams.length > 0 && !selectedTeamId) {
+      setSelectedTeamId(teams[0].id);
     }
-  }, [selectedTeam, fetchTeamMembers, fetchTeamJoinRequests]);
+  }, [teams, selectedTeamId]);
+
+  const teamMembersQuery = useQuery({
+    queryKey: ["team-members", selectedTeamId],
+    queryFn: async () => {
+      const data = await getMembersOfTeam(selectedTeamId);
+      return data.members;
+    },
+    enabled: !!selectedTeamId
+  });
+
+  const teamJoinRequestsQuery = useQuery({
+    queryKey: ["team-join-requests", selectedTeamId],
+    queryFn: async () => {
+      const data = await getJoinRequestsOfTeam(selectedTeamId);
+      return data.requests;
+    },
+    enabled: !!selectedTeamId
+  });
+
+  const teamMembers = teamMembersQuery.data ?? [];
+  const teamJoinRequests = teamJoinRequestsQuery.data ?? [];
+
+  const loading = teamsQuery.isLoading || teamMembersQuery.isLoading || teamJoinRequestsQuery.isLoading;
+
+  // Real-time sync: another member's create/update/delete/membership change
+  useEffect(() => {
+    if (!socket || !connected) return;
+
+    const handleTeamChanged = (payload) => {
+      queryClient.invalidateQueries({ queryKey: ["teams"] });
+      if (payload?.team_id) {
+        queryClient.invalidateQueries({ queryKey: ["team-members", payload.team_id] });
+        queryClient.invalidateQueries({ queryKey: ["team-join-requests", payload.team_id] });
+      }
+    };
+
+    socket.on("team_changed", handleTeamChanged);
+
+    return () => {
+      socket.off("team_changed", handleTeamChanged);
+    };
+  }, [socket, connected, queryClient]);
+
+  const handleConflict = useCallback(
+    async (err, invalidateKeys) => {
+      if (err?.status === 409) {
+        toast.error(err.message || "This was updated by someone else. Refreshing...");
+        await Promise.all(
+          invalidateKeys.map((queryKey) => queryClient.invalidateQueries({ queryKey }))
+        );
+        return true;
+      }
+      return false;
+    },
+    [queryClient]
+  );
 
   // Team actions
   const handleCreateTeam = useCallback(
     async (teamData) => {
       try {
-        setLoading(true);
         const newTeam = await createTeam(teamData);
-        await fetchTeams();
+        await queryClient.invalidateQueries({ queryKey: ["teams"] });
         setSelectedTeam(newTeam);
         return newTeam;
       } catch (err) {
         setError(err);
-      } finally {
-        setLoading(false);
       }
     },
-    [fetchTeams]
+    [queryClient, setSelectedTeam]
   );
 
   const handleUpdateTeam = useCallback(
     async (teamId, updates) => {
       try {
-        setLoading(true);
-        await updateTeam(teamId, updates);
-        await fetchTeams();
+        const currentTeam = teams.find((t) => t.id === teamId);
+        await updateTeam(teamId, { ...updates, updated_at: currentTeam?.updated_at });
+        await queryClient.invalidateQueries({ queryKey: ["teams"] });
       } catch (err) {
-        setError(err);
-      } finally {
-        setLoading(false);
+        const isConflict = await handleConflict(err, [["teams"]]);
+        if (!isConflict) setError(err);
       }
     },
-    [fetchTeams]
+    [teams, queryClient, handleConflict]
   );
 
   const handleDeleteTeam = useCallback(
     async (teamId) => {
       try {
-        setLoading(true);
         await deleteTeam(teamId);
-        await fetchTeams();
+        await queryClient.invalidateQueries({ queryKey: ["teams"] });
       } catch (err) {
         setError(err);
-      } finally {
-        setLoading(false);
       }
     },
-    [fetchTeams]
+    [queryClient]
   );
 
   const handleJoinTeam = useCallback(
     async (code) => {
       try {
-        setLoading(true);
         await joinTeam(code);
-        await fetchTeams();
+        await queryClient.invalidateQueries({ queryKey: ["teams"] });
       } catch (err) {
         setError(err);
-      } finally {
-        setLoading(false);
       }
     },
-    [fetchTeams]
+    [queryClient]
   );
 
   const handleLeaveTeam = useCallback(
     async (teamId) => {
       try {
-        setLoading(true);
         await leaveTeam(teamId);
-        await fetchTeams();
+        await queryClient.invalidateQueries({ queryKey: ["teams"] });
       } catch (err) {
         setError(err);
-      } finally {
-        setLoading(false);
       }
     },
-    [fetchTeams]
+    [queryClient]
   );
 
   const handleRemoveTeamMembers = useCallback(
     async (teamId, data) => {
       try {
-        setLoading(true);
         await removeMembersFromTeam(teamId, data);
-        await fetchTeamMembers(teamId);
+        await queryClient.invalidateQueries({ queryKey: ["team-members", teamId] });
       } catch (err) {
         setError(err);
-      } finally {
-        setLoading(false);
       }
     },
-    [fetchTeamMembers]
+    [queryClient]
   );
 
   const handleUpdateTeamRoleOfMember = useCallback(
     async (teamId, data) => {
       try {
-        setLoading(true);
         await updateTeamRoleOfMember(teamId, data);
-        await fetchTeamMembers(teamId);
+        await queryClient.invalidateQueries({ queryKey: ["team-members", teamId] });
       } catch (err) {
         setError(err);
-      } finally {
-        setLoading(false);
       }
     },
-    [fetchTeamMembers]
+    [queryClient]
   );
 
   const handleApproveJoinRequest = useCallback(
     async (requestId) => {
       try {
-        setLoading(true);
         await approveJoinRequest(requestId);
-        await fetchTeamJoinRequests(selectedTeam.id);
+        await queryClient.invalidateQueries({ queryKey: ["team-join-requests", selectedTeam?.id] });
+        await queryClient.invalidateQueries({ queryKey: ["team-members", selectedTeam?.id] });
       } catch (err) {
         setError(err);
-      } finally {
-        setLoading(false);
       }
     },
-    [fetchTeamJoinRequests, selectedTeam]
+    [queryClient, selectedTeam]
   );
 
   const handleRejectJoinRequest = useCallback(
     async (requestId) => {
       try {
-        setLoading(true);
         await rejectJoinRequest(requestId);
-        await fetchTeamJoinRequests(selectedTeam.id);
+        await queryClient.invalidateQueries({ queryKey: ["team-join-requests", selectedTeam?.id] });
       } catch (err) {
         setError(err);
-      } finally {
-        setLoading(false);
       }
     },
-    [fetchTeamJoinRequests, selectedTeam]
+    [queryClient, selectedTeam]
   );
 
   const contextValue = {

--- a/client/src/providers/query-provider.jsx
+++ b/client/src/providers/query-provider.jsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useState } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+export function QueryProvider({ children }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30 * 1000,
+            refetchOnWindowFocus: true,
+            retry: 1
+          }
+        }
+      })
+  );
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1025,6 +1025,18 @@
     postcss "^8.4.41"
     tailwindcss "4.1.7"
 
+"@tanstack/query-core@5.101.2":
+  version "5.101.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.101.2.tgz#c901fb76b68169ff5e1e44017404e7e2e90ce1af"
+  integrity sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==
+
+"@tanstack/react-query@^5":
+  version "5.101.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.101.2.tgz#d886331bcd29df84bc04c45d93192b8207d17c7f"
+  integrity sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==
+  dependencies:
+    "@tanstack/query-core" "5.101.2"
+
 "@tanstack/react-table@^8.21.3":
   version "8.21.3"
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.21.3.tgz#2c38c747a5731c1a07174fda764b9c2b1fb5e91b"

--- a/server/src/api/services/project-service.js
+++ b/server/src/api/services/project-service.js
@@ -6,6 +6,7 @@ import userModel from "../models/user-model.js";
 import conversationModel from "../models/conversation-model.js";
 import notificationModel from "../models/notification-model.js";
 import { emitNewNotification } from "../../socket/notification-socket.js";
+import { emitProjectChanged } from "../../socket/project-socket.js";
 import ApiError from "../../utils/api-error.js";
 import { sanitizeAllowedFields } from "../../utils/helper.js";
 
@@ -49,6 +50,8 @@ const createOneProject = async (data, actorId) => {
 
     const project = projectModel.getOneProjectById(projectId);
 
+    await emitProjectChanged(allowedData.team_id, projectId);
+
     return project;
   } catch (err) {
     throw err;
@@ -85,6 +88,18 @@ const updateOneProjectById = async (projectId, updateData, actorId) => {
       throw new ApiError(StatusCodes.FORBIDDEN, "Only owner can update project info");
     }
 
+    const project = await projectModel.getOneProjectById(projectId);
+
+    if (
+      updateData.updated_at &&
+      new Date(updateData.updated_at).getTime() !== new Date(project.updated_at).getTime()
+    ) {
+      throw new ApiError(
+        StatusCodes.CONFLICT,
+        "This project was updated by someone else. Please refresh and try again."
+      );
+    }
+
     const allowedData = sanitizeAllowedFields(updateData, ["name", "description"]);
 
     if (Object.keys(allowedData).length === 0) {
@@ -92,6 +107,8 @@ const updateOneProjectById = async (projectId, updateData, actorId) => {
     }
 
     await projectModel.updateOneProjectById(projectId, allowedData);
+
+    await emitProjectChanged(project.team_id, projectId);
 
     return projectId;
   } catch (err) {
@@ -113,10 +130,14 @@ const deleteOneProjectById = async (projectId, actorId) => {
       throw new ApiError(StatusCodes.FORBIDDEN, "Only owner can delete project");
     }
 
+    const project = await projectModel.getOneProjectById(projectId);
+
     const conversation = await conversationModel.getOneConversationByProjectId(projectId);
     await conversationModel.deleteOneConversationById(conversation.id);
 
     await projectModel.deleteOneProjectById(projectId);
+
+    await emitProjectChanged(project.team_id, projectId);
 
     return projectId;
   } catch (err) {
@@ -164,6 +185,8 @@ const addMembersToProject = async (projectId, userIds, actorId) => {
       );
     }
 
+    await emitProjectChanged(project.team_id, projectId);
+
     return projectId;
   } catch (err) {
     throw err;
@@ -204,6 +227,8 @@ const removeMembersFromProject = async (projectId, userIds, actorId) => {
       throw new ApiError(StatusCodes.FORBIDDEN, "Owner can not delete self");
     }
 
+    const project = await projectModel.getOneProjectById(projectId);
+
     const conversation = await conversationModel.getOneConversationByProjectId(projectId);
     await conversationModel.removeParticipantsFromConversation(conversation.id, userIds);
 
@@ -217,6 +242,8 @@ const removeMembersFromProject = async (projectId, userIds, actorId) => {
         `<@${user.full_name}> was removed from the project by <@${actor.full_name}>.`
       );
     }
+
+    await emitProjectChanged(project.team_id, projectId);
 
     return projectId;
   } catch (err) {
@@ -242,6 +269,8 @@ const updateProjectRoleOfUser = async (projectId, updateData, actorId) => {
       throw new ApiError(StatusCodes.FORBIDDEN, "Owner can not update self");
     }
 
+    const project = await projectModel.getOneProjectById(projectId);
+
     await projectModel.updateProjectRoleOfUser(projectId, updateData.user_id, updateData.role);
 
     const actor = await userModel.getOneUserById(actorId);
@@ -250,6 +279,8 @@ const updateProjectRoleOfUser = async (projectId, updateData, actorId) => {
       projectId,
       `Role of <@${user.full_name}> in the project has been changed by <@${actor.full_name}>.`
     );
+
+    await emitProjectChanged(project.team_id, projectId);
 
     return projectId;
   } catch (err) {

--- a/server/src/api/services/task-service.js
+++ b/server/src/api/services/task-service.js
@@ -9,6 +9,7 @@ import ApiError from "../../utils/api-error.js";
 import embeddingProvider from "../../config/embedding-provider.js";
 import storageProvider from "../../config/storage-provider.js";
 import { emitNewNotification } from "../../socket/notification-socket.js";
+import { emitTaskChanged } from "../../socket/task-socket.js";
 import { sanitizeAllowedFields } from "../../utils/helper.js";
 
 const createOneTask = async (data, actorId) => {
@@ -60,6 +61,8 @@ const createOneTask = async (data, actorId) => {
     const taskAssignees = await taskModel.getAssigneesOfTask(taskId);
 
     const formattedTask = { ...task, assignees: taskAssignees };
+
+    await emitTaskChanged(project_id);
 
     return formattedTask;
   } catch (err) {
@@ -118,6 +121,16 @@ const updateOneTaskById = async (id, data, actorId) => {
       throw new ApiError(StatusCodes.FORBIDDEN, "Only members of project can access this");
     }
 
+    if (
+      data.updated_at &&
+      new Date(data.updated_at).getTime() !== new Date(task.updated_at).getTime()
+    ) {
+      throw new ApiError(
+        StatusCodes.CONFLICT,
+        "This task was updated by someone else. Please refresh and try again."
+      );
+    }
+
     const allowedData = sanitizeAllowedFields(data, [
       "title",
       "description",
@@ -172,6 +185,8 @@ const updateOneTaskById = async (id, data, actorId) => {
       );
     }
 
+    await emitTaskChanged(task.project_id);
+
     return task.id;
   } catch (err) {
     throw err;
@@ -199,6 +214,8 @@ const deleteOneTaskById = async (id, actorId) => {
       details: { deleted_task_title: task.title }
     });
     await taskModel.deleteOneTaskById(task.id);
+
+    await emitTaskChanged(task.project_id);
 
     return task.id;
   } catch (err) {

--- a/server/src/api/services/team-service.js
+++ b/server/src/api/services/team-service.js
@@ -7,6 +7,7 @@ import conversationModel from "../models/conversation-model.js";
 import notificationModel from "../models/notification-model.js";
 import ApiError from "../../utils/api-error.js";
 import { emitNewNotification } from "../../socket/notification-socket.js";
+import { emitTeamChanged } from "../../socket/team-socket.js";
 import { sanitizeAllowedFields, generateTeamCode } from "../../utils/helper.js";
 
 const createOneTeam = async (data, actorId) => {
@@ -75,6 +76,18 @@ const updateOneTeamById = async (teamId, updateData, actorId) => {
       throw new ApiError(StatusCodes.FORBIDDEN, "Only owner can update team info");
     }
 
+    const team = await teamModel.getOneTeamById(teamId);
+
+    if (
+      updateData.updated_at &&
+      new Date(updateData.updated_at).getTime() !== new Date(team.updated_at).getTime()
+    ) {
+      throw new ApiError(
+        StatusCodes.CONFLICT,
+        "This team was updated by someone else. Please refresh and try again."
+      );
+    }
+
     const allowedData = sanitizeAllowedFields(updateData, ["name", "description", "join_policy"]);
 
     if (Object.keys(allowedData).length === 0) {
@@ -95,6 +108,8 @@ const updateOneTeamById = async (teamId, updateData, actorId) => {
 
     await teamModel.updateOneTeamById(teamId, allowedData);
 
+    await emitTeamChanged(teamId);
+
     return teamId;
   } catch (err) {
     throw err;
@@ -114,6 +129,8 @@ const deleteOneTeamById = async (teamId, actorId) => {
     if (role != "owner") {
       throw new ApiError(StatusCodes.FORBIDDEN, "Only owner can delete team");
     }
+
+    await emitTeamChanged(teamId);
 
     const conversation = await conversationModel.getOneConversationByTeamId(teamId);
     await conversationModel.deleteOneConversationById(conversation.id);
@@ -185,6 +202,8 @@ const removeMembersFromTeam = async (teamId, userIds, actorId) => {
       );
     }
 
+    await emitTeamChanged(teamId);
+
     return teamId;
   } catch (err) {
     throw err;
@@ -218,6 +237,8 @@ const updateTeamRoleOfUser = async (teamId, updateData, actorId) => {
       `Role of <@${user.full_name}> in the team has been changed by <@${actor.full_name}>.`
     );
 
+    await emitTeamChanged(teamId);
+
     return teamId;
   } catch (err) {
     throw err;
@@ -247,6 +268,8 @@ const joinOneTeamByCode = async (code, actorId) => {
       await conversationModel.addParticipantsToConversation(conversation.id, [actorId]);
 
       await notifyMembersOfTeam(team.id, `<@${user.full_name}> has joined the team.`);
+
+      await emitTeamChanged(team.id);
     } else {
       const isRequestPending = await teamModel.isTeamJoinRequestPending(team.id, actorId);
 
@@ -254,6 +277,8 @@ const joinOneTeamByCode = async (code, actorId) => {
         await teamModel.createOneTeamJoinRequest(team.id, actorId);
 
         await notifyMembersOfTeam(team.id, `<@${user.full_name}> has requested to join the team.`);
+
+        await emitTeamChanged(team.id);
       }
     }
 
@@ -295,6 +320,8 @@ const leaveOneTeamById = async (teamId, actorId) => {
 
     const user = await userModel.getOneUserById(actorId);
     await notifyMembersOfTeam(teamId, `<@${user.full_name}> has left the team.`);
+
+    await emitTeamChanged(teamId);
 
     return teamId;
   } catch (err) {
@@ -354,6 +381,8 @@ const approveTeamJoinRequest = async (requestId, actorId) => {
       `Request to join the team of <@${user.full_name}> was approved by <@${actor.full_name}>.`
     );
 
+    await emitTeamChanged(request.team_id);
+
     return request.team_id;
   } catch (err) {
     throw err;
@@ -387,6 +416,8 @@ const rejectTeamJoinRequest = async (requestId, actorId) => {
       request.team_id,
       `Request to join the team of <@${user.full_name}> was rejected by <@${actor.full_name}>.`
     );
+
+    await emitTeamChanged(request.team_id);
 
     return request.team_id;
   } catch (err) {

--- a/server/src/api/validations/project-validation.js
+++ b/server/src/api/validations/project-validation.js
@@ -21,7 +21,8 @@ const validateUpdateProject = validate(
     body: z
       .object({
         name: z.string().min(1).max(100).optional(),
-        description: z.string().max(1000).optional()
+        description: z.string().max(1000).optional(),
+        updated_at: z.coerce.date().optional()
       })
       .strict(),
     params: z

--- a/server/src/api/validations/task-validation.js
+++ b/server/src/api/validations/task-validation.js
@@ -32,7 +32,8 @@ const validateUpdateTask = validate(
         due_date: z.coerce.date().optional(),
         completed_at: z.coerce.date().optional(),
         position: z.coerce.number().int().positive().optional(),
-        assignees: z.array(z.string().uuid()).optional()
+        assignees: z.array(z.string().uuid()).optional(),
+        updated_at: z.coerce.date().optional()
       })
       .strict(),
     params: z

--- a/server/src/api/validations/team-validation.js
+++ b/server/src/api/validations/team-validation.js
@@ -22,7 +22,8 @@ const validateUpdateTeam = validate(
       .object({
         name: z.string().max(100).optional(),
         description: z.string().max(1000).optional(),
-        join_policy: z.enum(["auto", "manual"]).optional()
+        join_policy: z.enum(["auto", "manual"]).optional(),
+        updated_at: z.coerce.date().optional()
       })
       .strict(),
     params: z.object({}).optional(),

--- a/server/src/socket/project-socket.js
+++ b/server/src/socket/project-socket.js
@@ -1,0 +1,16 @@
+import { getIoInstance } from "./index.js";
+import teamModel from "../api/models/team-model.js";
+
+const emitProjectChanged = async (teamId, projectId) => {
+  const io = getIoInstance();
+
+  if (!io || !teamId) return;
+
+  const members = await teamModel.getMembersOfTeam(teamId);
+
+  for (const member of members) {
+    io.to(`user_${member.id}`).emit("project_changed", { team_id: teamId, project_id: projectId });
+  }
+};
+
+export { emitProjectChanged };

--- a/server/src/socket/task-socket.js
+++ b/server/src/socket/task-socket.js
@@ -1,0 +1,16 @@
+import { getIoInstance } from "./index.js";
+import projectModel from "../api/models/project-model.js";
+
+const emitTaskChanged = async (projectId) => {
+  const io = getIoInstance();
+
+  if (!io || !projectId) return;
+
+  const members = await projectModel.getMembersOfProject(projectId);
+
+  for (const member of members) {
+    io.to(`user_${member.id}`).emit("task_changed", { project_id: projectId });
+  }
+};
+
+export { emitTaskChanged };

--- a/server/src/socket/team-socket.js
+++ b/server/src/socket/team-socket.js
@@ -1,0 +1,16 @@
+import { getIoInstance } from "./index.js";
+import teamModel from "../api/models/team-model.js";
+
+const emitTeamChanged = async (teamId) => {
+  const io = getIoInstance();
+
+  if (!io || !teamId) return;
+
+  const members = await teamModel.getMembersOfTeam(teamId);
+
+  for (const member of members) {
+    io.to(`user_${member.id}`).emit("team_changed", { team_id: teamId });
+  }
+};
+
+export { emitTeamChanged };


### PR DESCRIPTION
## Summary
- Add Socket.IO broadcasts for task/project/team create/update/delete/membership changes so other open tabs/users see changes without a manual reload.
- Migrate use-team/use-project/use-task hooks from ad-hoc Context+useState fetching to TanStack Query, invalidated by socket events (with refetchOnWindowFocus as a fallback).
- Add optimistic concurrency (409 Conflict) checks on task/project/team updates based on updated_at, surfaced as a toast instead of silently overwriting concurrent edits.

## Test plan
- [x] `yarn build` passes on client
- [x] `node --check` passes on all modified/new server files
- [x] Server boots locally against the Railway DB and responds 200 on /health-check
- [ ] Manual: open the same board in two tabs/users, confirm task/project/team edits appear live without reload
- [ ] Manual: confirm editing a stale task/project/team shows a conflict toast instead of overwriting