### PR TITLE
fix(admin): transfer-ownership member picker was always empty

### DIFF
--- a/client/src/components/admin/actions/transfer-project-ownership-dialog.jsx
+++ b/client/src/components/admin/actions/transfer-project-ownership-dialog.jsx
@@ -62,7 +62,9 @@ export default function TransferProjectOwnershipDialog({
       try {
         const detail = await getProjectDetail(project.id);
         if (!cancelled) {
-          setMembers((detail.members || []).filter((member) => member.id !== project.owner_id));
+          setMembers(
+            (detail.project?.members || []).filter((member) => member.id !== project.owner_id)
+          );
         }
       } finally {
         if (!cancelled) setLoadingMembers(false);

--- a/client/src/components/admin/actions/transfer-team-ownership-dialog.jsx
+++ b/client/src/components/admin/actions/transfer-team-ownership-dialog.jsx
@@ -57,7 +57,9 @@ export default function TransferTeamOwnershipDialog({ isOpen, onOpenChange, team
       try {
         const detail = await getTeamDetail(team.id);
         if (!cancelled) {
-          setMembers((detail.members || []).filter((member) => member.id !== team.owner_id));
+          setMembers(
+            (detail.team?.members || []).filter((member) => member.id !== team.owner_id)
+          );
         }
       } finally {
         if (!cancelled) setLoadingMembers(false);


### PR DESCRIPTION
## Summary
- Transfer Ownership dialogs (Team/Project) in the admin panel read `detail.members` from the detail-fetch response, but the API wraps the resource one level deeper (`{ team: {...} }` / `{ project: {...} }`), so `members` was always `undefined` and the picker showed no one.

## Test plan
- [ ] Manual: as admin, open Transfer Ownership on a team/project with 2+ members, confirm the dropdown now lists the other members