### PR TITLE
fix(admin): Health tab spins forever due to blocked-SMTP hang

### DIFF
--- a/client/src/components/admin/admin-health-panel.jsx
+++ b/client/src/components/admin/admin-health-panel.jsx
@@ -25,7 +25,7 @@ function formatUptime(seconds) {
 }
 
 export default function AdminHealthPanel() {
-  const { health, fetchHealth, loading } = useAdmin();
+  const { health, error, fetchHealth, healthLoading } = useAdmin();
 
   useEffect(() => {
     fetchHealth();
@@ -33,15 +33,16 @@ export default function AdminHealthPanel() {
 
   return (
     <div className="space-y-4">
+      {error && <p className="text-sm text-red-500">{error.message}</p>}
       <div className="flex justify-end">
         <Button
           variant="outline"
           size="sm"
           className="flex flex-row items-center gap-2"
           onClick={() => fetchHealth()}
-          disabled={loading}
+          disabled={healthLoading}
         >
-          <RefreshCw className={cn("h-4 w-4", loading && "animate-spin")} />
+          <RefreshCw className={cn("h-4 w-4", healthLoading && "animate-spin")} />
           Refresh
         </Button>
       </div>

--- a/client/src/hooks/use-admin.js
+++ b/client/src/hooks/use-admin.js
@@ -61,17 +61,7 @@ export function AdminProvider({ children }) {
     },
     enabled: false
   });
-  const fetchStats = useCallback(
-    () =>
-      queryClient.fetchQuery({
-        queryKey: ["admin-stats"],
-        queryFn: async () => {
-          const data = await getStats();
-          return data.stats;
-        }
-      }),
-    [queryClient]
-  );
+  const fetchStats = useCallback(() => statsQuery.refetch(), [statsQuery.refetch]);
 
   const healthQuery = useQuery({
     queryKey: ["admin-health"],
@@ -81,17 +71,7 @@ export function AdminProvider({ children }) {
     },
     enabled: false
   });
-  const fetchHealth = useCallback(
-    () =>
-      queryClient.fetchQuery({
-        queryKey: ["admin-health"],
-        queryFn: async () => {
-          const data = await getHealth();
-          return data.health;
-        }
-      }),
-    [queryClient]
-  );
+  const fetchHealth = useCallback(() => healthQuery.refetch(), [healthQuery.refetch]);
 
   const loading =
     usersQuery.isFetching ||
@@ -99,6 +79,9 @@ export function AdminProvider({ children }) {
     projectsQuery.isFetching ||
     statsQuery.isFetching ||
     healthQuery.isFetching;
+
+  const statsLoading = statsQuery.isFetching;
+  const healthLoading = healthQuery.isFetching;
 
   const error =
     usersQuery.error ||
@@ -200,9 +183,11 @@ export function AdminProvider({ children }) {
     handleTransferProjectOwnership,
 
     stats: statsQuery.data ?? null,
+    statsLoading,
     fetchStats,
 
     health: healthQuery.data ?? null,
+    healthLoading,
     fetchHealth
   };
 

--- a/server/src/api/services/admin-service.js
+++ b/server/src/api/services/admin-service.js
@@ -317,11 +317,21 @@ const getSystemStats = async () => {
   }
 };
 
-const checkDependency = async (name, fn) => {
+const withTimeout = (promise, ms) =>
+  Promise.race([
+    promise,
+    new Promise((_, reject) => setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms))
+  ]);
+
+// Some dependency checks (e.g. raw SMTP .verify()) can hang far longer than a
+// health check should ever take — notably Railway blocks outbound SMTP on
+// sub-Pro plans, so an unreachable mail server would otherwise stall the
+// whole /admin/health response indefinitely. Bound every check individually.
+const checkDependency = async (name, fn, timeoutMs = 5000) => {
   const start = Date.now();
 
   try {
-    await fn();
+    await withTimeout(fn(), timeoutMs);
 
     return { name, status: "up", latency_ms: Date.now() - start };
   } catch (err) {


### PR DESCRIPTION
## Summary
- `getSystemHealth()`'s mail dependency check calls raw SMTP `.verify()`, which hangs indefinitely since Railway blocks outbound SMTP on the project's current plan — this stalled the entire `/admin/health` response, so the client's refetch never resolved and the Refresh button spun forever with no data.
- Added a 5s timeout per dependency check so a blocked/slow dependency reports "down" instead of hanging the whole endpoint.
- Simplified fetchStats/fetchHealth to use the query's own `refetch()`, scoped the Health tab's spinner to health-specific loading (was reacting to unrelated users/teams/projects fetches too), and surfaced fetch errors in the Health panel.

## Note
This is a stopgap — the underlying fix for email (switching off raw SMTP to an HTTPS transactional email API like Resend) is still pending as a separate piece of work.

## Test plan
- [ ] Manual: open Admin > Health, confirm dependency cards populate within ~5s (mail card should show "down" until SMTP is replaced, but the page must not hang)