### PR TITLE
fix(team): /app/team crashes with null selectedTeam on fresh load

### DIFF
--- a/client/src/components/team/project-manage/project-information-card.jsx
+++ b/client/src/components/team/project-manage/project-information-card.jsx
@@ -7,6 +7,8 @@ export default function ProjectInformationCard() {
   const { selectedProject } = useProject();
   const { selectedTeam } = useTeam();
 
+  if (!selectedProject) return null;
+
   return (
     <Card className="w-full gap-2 rounded-md shadow-none">
       <CardHeader>
@@ -23,7 +25,7 @@ export default function ProjectInformationCard() {
         <div className="flex flex-col gap-2">
           <div>
             <h3 className="text-sm font-semibold">Team</h3>
-            <p className="text-sm text-muted-foreground line-clamp-3">{selectedTeam.name}</p>
+            <p className="text-sm text-muted-foreground line-clamp-3">{selectedTeam?.name}</p>
           </div>
           <div>
             <h3 className="text-sm font-semibold">Description</h3>

--- a/client/src/components/team/team-manage/team-infomation-card.jsx
+++ b/client/src/components/team/team-manage/team-infomation-card.jsx
@@ -5,6 +5,8 @@ import { useTeam } from "@/hooks/use-team";
 export default function TeamInformationCard() {
   const { selectedTeam } = useTeam();
 
+  if (!selectedTeam) return null;
+
   return (
     <Card className="w-full gap-2 rounded-md shadow-none">
       <CardHeader>

--- a/client/src/components/team/team-manage/team-manage-window.jsx
+++ b/client/src/components/team/team-manage/team-manage-window.jsx
@@ -12,7 +12,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { useTeam } from "@/hooks/use-team";
 
 export default function TeamManageWindow() {
-  const { teams } = useTeam();
+  const { selectedTeam } = useTeam();
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -26,7 +26,7 @@ export default function TeamManageWindow() {
 
   return (
     <div className="w-full h-full bg-white">
-      {teams.length ? (
+      {selectedTeam ? (
         <>
           <Tabs value={tab} onValueChange={changeTab} className="w-full h-full bg-white">
             <TabsList className="justify-start w-full px-6 gap-x-6 rounded-none border-b bg-white">


### PR DESCRIPTION
## Summary
- `TeamManageWindow` gated its content on `teams.length` but unconditionally rendered `TeamInformationCard`, which reads `selectedTeam.name` with no guard. `selectedTeam` is derived separately (`teams.find(...) ?? null`) and is legitimately `null` for one render on a fresh `/app/team` load — the teams list can arrive before the "auto-select first team" effect commits — producing `Cannot read properties of null (reading 'name')` and a full client-side crash.
- Fixed the guard to check `selectedTeam` itself, and added defensive null-checks in `TeamInformationCard`/`ProjectInformationCard`.

## Test plan
- [ ] Manual: hard-reload directly on `/app/team`, confirm no crash and the team info loads correctly