### PR TITLE
feat(task): confirm before deleting a task

### DIFF
--- a/client/src/components/task/delete-task-dialog.jsx
+++ b/client/src/components/task/delete-task-dialog.jsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { OctagonAlert } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { useTask } from "@/hooks/use-task";
+
+export default function DeleteTaskDialog({ isOpen, onOpenChange, task }) {
+  const { handleDeleteTask } = useTask();
+
+  const handleConfirm = async () => {
+    await handleDeleteTask(task.id);
+    onOpenChange(false);
+  };
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-xl font-bold">Delete Task</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="flex flex-row items-center gap-4 p-4 my-4 rounded-md bg-red-100 border-1 border-red-600 text-red-600">
+              <OctagonAlert className="h-10 w-10" />
+              This will permanently delete "{task.title}". This action can not be undone.
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="flex flex-row justify-end gap-4">
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <Button variant="destructive" onClick={handleConfirm}>
+            Confirm
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/client/src/components/task/task-actions.jsx
+++ b/client/src/components/task/task-actions.jsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
-import { useCallback } from "react";
+import { useState, useCallback } from "react";
 import { MoreVertical, Info, Trash } from "lucide-react";
 
 import TaskDetailsSheet from "@/components/task/task-details-sheet";
+import DeleteTaskDialog from "@/components/task/delete-task-dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -12,10 +13,9 @@ import {
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
-import { useTask } from "@/hooks/use-task";
 
 export default function TaskActions({ task }) {
-  const { handleDeleteTask } = useTask();
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -46,7 +46,7 @@ export default function TaskActions({ task }) {
           </DropdownMenuItem>
           <DropdownMenuItem
             className="text-red-500 focus:text-red-500"
-            onClick={() => handleDeleteTask(task.id)}
+            onSelect={() => setIsDeleteDialogOpen(true)}
           >
             <Trash className="h-4 w-4" />
             <span>Delete</span>
@@ -54,6 +54,7 @@ export default function TaskActions({ task }) {
         </DropdownMenuContent>
       </DropdownMenu>
       <TaskDetailsSheet task={task} />
+      <DeleteTaskDialog isOpen={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen} task={task} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Deleting a task from the card dropdown fired immediately with no confirmation, risking accidental deletes.
- Added a confirmation dialog (same AlertDialog pattern used for team/project/user delete actions elsewhere) before calling handleDeleteTask.

## Test plan
- [ ] Manual: open a task's "..." menu, click Delete, confirm a dialog appears and Cancel keeps the task