### PR TITLE
fix(auth): force-logout leaves users stuck, unable to log out

### DIFF
--- a/client/src/app/(app)/layout.jsx
+++ b/client/src/app/(app)/layout.jsx
@@ -18,8 +18,8 @@ export default async function RootLayout({ children }) {
   const defaultOpen = cookieStore.get("sidebar_state")?.value === "true";
 
   return (
-    <QueryProvider>
-      <SessionProvider>
+    <SessionProvider>
+      <QueryProvider>
         <SocketProvider>
           <NotificationProvider>
             <TeamProvider>
@@ -41,7 +41,7 @@ export default async function RootLayout({ children }) {
             </TeamProvider>
           </NotificationProvider>
         </SocketProvider>
-      </SessionProvider>
-    </QueryProvider>
+      </QueryProvider>
+    </SessionProvider>
   );
 }

--- a/client/src/hooks/use-socket.js
+++ b/client/src/hooks/use-socket.js
@@ -12,7 +12,7 @@ export function useSocket() {
 }
 
 export function SocketProvider({ children }) {
-  const { user, loading } = useSession(); // get current user from session
+  const { user, loading, logout } = useSession(); // get current user from session
   const socketRef = useRef(null);
   const [connected, setConnected] = useState(false);
 
@@ -26,6 +26,14 @@ export function SocketProvider({ children }) {
 
       socketRef.current.on("connect", () => {
         setConnected(true);
+      });
+
+      // An admin disabled/force-logged-out this account — the server has
+      // already killed this socket connection; drop the client-side session
+      // and send the user to login right away instead of leaving them on a
+      // page whose API calls now silently 401.
+      socketRef.current.on("force_logout", () => {
+        logout();
       });
 
       // Emit setup event with userId to authenticate socket

--- a/client/src/providers/query-provider.jsx
+++ b/client/src/providers/query-provider.jsx
@@ -1,12 +1,32 @@
 "use client";
 
-import { useState } from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useRef, useState } from "react";
+import { QueryCache, QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { useSession } from "@/hooks/use-session";
 
 export function QueryProvider({ children }) {
+  const { refreshSession } = useSession();
+  // A ref so the cache's onError (bound once, at client creation) always
+  // calls the latest refreshSession function instead of closing over a stale one.
+  const refreshSessionRef = useRef(refreshSession);
+  refreshSessionRef.current = refreshSession;
+
   const [queryClient] = useState(
     () =>
       new QueryClient({
+        queryCache: new QueryCache({
+          onError: (error) => {
+            // A background query 401ing usually just means the access token
+            // expired before its scheduled refresh fired — try to refresh
+            // once. If the session was actually revoked (disabled account,
+            // force-logout), refreshSession's own failure path already
+            // clears the session and redirects to login.
+            if (error?.status === 401) {
+              refreshSessionRef.current?.();
+            }
+          }
+        }),
         defaultOptions: {
           queries: {
             staleTime: 30 * 1000,

--- a/server/src/api/routes/auth-route.js
+++ b/server/src/api/routes/auth-route.js
@@ -12,7 +12,7 @@ const authRoute = (router) => {
 
   router.route("/auth/refresh").post(authController.refreshSession);
 
-  router.use("/auth/logout", authMiddleware.authenticate);
+  router.use("/auth/logout", authMiddleware.authenticateAllowRevoked);
   router.route("/auth/logout").post(authController.logout);
 
   router.use("/mail/verify-email", authMiddleware.authenticate);

--- a/server/src/api/services/admin-service.js
+++ b/server/src/api/services/admin-service.js
@@ -26,6 +26,9 @@ const disconnectUserSockets = (userId) => {
 
   for (const socket of io.sockets.sockets.values()) {
     if (socket.data?.user?.id === userId) {
+      // Let the client redirect to /auth/login immediately instead of only
+      // discovering the revoked session next time an API call 401s.
+      socket.emit("force_logout");
       socket.disconnect(true);
     }
   }

--- a/server/src/middlewares/auth-middleware.js
+++ b/server/src/middlewares/auth-middleware.js
@@ -49,6 +49,33 @@ const authenticate = async (req, res, next) => {
   }
 };
 
+// Logging out an already-revoked session (disabled account, force-logout, or
+// a stale token_version) must still succeed at clearing cookies — otherwise a
+// force-logged-out user can never log out at all. Only verify the token's
+// signature, not whether the DB still considers this session live.
+const authenticateAllowRevoked = (req, res, next) => {
+  try {
+    const token = req.cookies ? req.cookies.access_token : null;
+
+    if (!token) {
+      return next(new ApiError(StatusCodes.UNAUTHORIZED, "Please login to access this"));
+    }
+
+    const decoded = jwtProvider.verifyToken(token, process.env.ACCESS_TOKEN_SECRET);
+
+    req.user = {
+      id: decoded.id,
+      email: decoded.email,
+      role: decoded.role,
+      exp: decoded.exp
+    };
+
+    next();
+  } catch (error) {
+    next(error);
+  }
+};
+
 const authorizeAdmin = (req, res, next) => {
   try {
     if (!req.user) {
@@ -96,6 +123,7 @@ const authenticateSocket = async (socket, next) => {
 
 export default {
   authenticate,
+  authenticateAllowRevoked,
   authorizeAdmin,
   authenticateSocket
 };


### PR DESCRIPTION
## Summary
- `/auth/logout` required the strict auth middleware (checks token_version/is_enabled against the DB), so once a session was revoked, logout itself 401'd before ever clearing cookies — the user could never actually log out. Now uses a lenient signature-only check.
- Background queries (teams/tasks/etc.) started 401ing after revocation with nothing handling it client-side, leaving the UI blank instead of redirecting. The QueryClient now reacts to any 401 by attempting a session refresh (its existing failure path already clears session + redirects to login).
- Force-logout/disable-account now emits a `force_logout` socket event to the affected user's live connection before disconnecting it, so an open tab is kicked to login immediately instead of only on the next failed request.

## Test plan
- [ ] Manual: as admin, force-logout or disable another currently-logged-in user, confirm their open tab redirects to login promptly and clicking Logout (if they get there first) actually works