### PR TITLE
feat(presence): real online/offline status in chat and admin

### DIFF
--- a/client/src/components/admin/admin-user-column.jsx
+++ b/client/src/components/admin/admin-user-column.jsx
@@ -6,8 +6,27 @@ import { BadgeCheck, BadgeX } from "lucide-react";
 import AdminUserActions from "@/components/admin/admin-user-actions";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import { useSocket } from "@/hooks/use-socket";
 import { getInitials, pickAvatarColor } from "@/lib/user-utils";
 import { cn, formatDate, capitalCase } from "@/lib/utils";
+
+function OnlineStatusCell({ user }) {
+  const { onlineUserIds } = useSocket();
+  const isOnline = onlineUserIds.has(user.id);
+
+  return (
+    <div className="flex flex-col items-center gap-0.5">
+      <Badge
+        className={cn("rounded-sm", isOnline ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-600")}
+      >
+        {isOnline ? "Online" : "Offline"}
+      </Badge>
+      {!isOnline && user.last_active && (
+        <span className="text-[10px] text-muted-foreground">{formatDate(user.last_active)}</span>
+      )}
+    </div>
+  );
+}
 
 export function getColumns(listParams) {
   return [
@@ -80,6 +99,11 @@ export function getColumns(listParams) {
           </Badge>
         );
       }
+    },
+    {
+      accessorKey: "is_active",
+      header: "Online",
+      cell: ({ row }) => <OnlineStatusCell user={row.original} />
     },
     {
       accessorKey: "email_verified",

--- a/client/src/components/chat/chat-header.jsx
+++ b/client/src/components/chat/chat-header.jsx
@@ -7,11 +7,13 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useChat } from "@/hooks/use-chat";
+import { useSocket } from "@/hooks/use-socket";
 import { getInitials, pickAvatarColor } from "@/lib/user-utils";
 import { cn, capitalCase } from "@/lib/utils";
 
 export default function ChatHeader() {
   const { conversations, selectedConversationId } = useChat();
+  const { onlineUserIds } = useSocket();
 
   const currConversation = useMemo(
     () => conversations.find((c) => c.id === selectedConversationId),
@@ -39,6 +41,9 @@ export default function ChatHeader() {
             <FolderKanban />
           )}
         </AvatarFallback>
+        {currConversation.type === "direct" && onlineUserIds.has(currConversation.direct_user_id) && (
+          <span className="absolute bottom-0 right-0 h-3 w-3 rounded-full bg-green-500 border-2 border-white" />
+        )}
       </Avatar>
       <div className="max-w-4/5">
         <div className="flex-none text-xl font-semibold truncate">

--- a/client/src/components/chat/nav-conversation-item.jsx
+++ b/client/src/components/chat/nav-conversation-item.jsx
@@ -3,11 +3,13 @@ import { Users, FolderKanban } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { useChat } from "@/hooks/use-chat";
+import { useSocket } from "@/hooks/use-socket";
 import { getInitials, pickAvatarColor } from "@/lib/user-utils";
 import { cn, capitalCase, formatShortTimestamp } from "@/lib/utils";
 
 export default function NavConversationItem({ conversation }) {
   const { selectedConversationId, changeConversation } = useChat();
+  const { onlineUserIds } = useSocket();
   const selected = conversation.id === selectedConversationId;
 
   return (
@@ -35,6 +37,9 @@ export default function NavConversationItem({ conversation }) {
               <FolderKanban />
             )}
           </AvatarFallback>
+          {conversation.type === "direct" && onlineUserIds.has(conversation.direct_user_id) && (
+            <span className="absolute bottom-0 right-0 h-3 w-3 rounded-full bg-green-500 border-2 border-white" />
+          )}
         </Avatar>
         {conversation.unread_count > 0 && (
           <Badge className="text-xs bg-prussian-blue absolute h-5 w-5 -bottom-1 -right-1 transform -translate-y-0.5 z-10">

--- a/client/src/hooks/use-socket.js
+++ b/client/src/hooks/use-socket.js
@@ -15,6 +15,7 @@ export function SocketProvider({ children }) {
   const { user, loading, logout } = useSession(); // get current user from session
   const socketRef = useRef(null);
   const [connected, setConnected] = useState(false);
+  const [onlineUserIds, setOnlineUserIds] = useState(new Set());
 
   useEffect(() => {
     // Only connect when session is loaded and user is present
@@ -36,6 +37,24 @@ export function SocketProvider({ children }) {
         logout();
       });
 
+      // Full snapshot on connect, then incremental updates as people
+      // connect/disconnect elsewhere.
+      socketRef.current.on("online_users", (userIds) => {
+        setOnlineUserIds(new Set(userIds));
+      });
+
+      socketRef.current.on("user_status_changed", ({ user_id, is_active }) => {
+        setOnlineUserIds((prev) => {
+          const next = new Set(prev);
+          if (is_active) {
+            next.add(user_id);
+          } else {
+            next.delete(user_id);
+          }
+          return next;
+        });
+      });
+
       // Emit setup event with userId to authenticate socket
       socketRef.current.emit("setup");
       setConnected(true);
@@ -47,12 +66,13 @@ export function SocketProvider({ children }) {
         socketRef.current.disconnect();
         socketRef.current = null;
         setConnected(false);
+        setOnlineUserIds(new Set());
       }
     };
   }, [loading, user]); // rerun when loading or user changes
 
   return (
-    <SocketContext.Provider value={{ socket: socketRef.current, connected }}>
+    <SocketContext.Provider value={{ socket: socketRef.current, connected, onlineUserIds }}>
       {children}
     </SocketContext.Provider>
   );

--- a/server/src/api/models/conversation-model.js
+++ b/server/src/api/models/conversation-model.js
@@ -213,10 +213,25 @@ const getDetailOfConversation = async (conversation_id, user_id) => {
           [user_id]
         ),
         db.raw(
-          `(SELECT COUNT(*) 
-            FROM conversation_participants cp3 
+          `(SELECT COUNT(*)
+            FROM conversation_participants cp3
             WHERE cp3.conversation_id = v.conversation_id
           ) AS participant_count`
+        ),
+        // The other participant's id, for direct conversations, so the client
+        // can look up their live online/offline status.
+        db.raw(
+          `CASE
+            WHEN v.type = 'direct' THEN (
+              SELECT uv.id
+              FROM conversation_participants cp2
+              JOIN user_public_view uv ON cp2.user_id = uv.id
+              WHERE cp2.conversation_id = v.conversation_id AND uv.id <> ?
+              LIMIT 1
+            )
+            ELSE NULL
+          END AS direct_user_id`,
+          [user_id]
         ),
         db.raw("COALESCE(um.unread_count, 0) AS unread_count")
       ])

--- a/server/src/api/services/auth-service.js
+++ b/server/src/api/services/auth-service.js
@@ -61,9 +61,9 @@ const login = async (data) => {
       throw new ApiError(StatusCodes.FORBIDDEN, "This account has been disabled");
     }
 
-    await userModel.updateOneUserById(existedUser.id, { is_active: true });
-
-    const user = await userModel.getOneUserById(existedUser.id);
+    // is_active/last_active are now driven by real Socket.IO presence
+    // (server/src/socket/index.js), not by login/logout requests.
+    const user = existedUser;
     return sanitizeUser(user);
   } catch (err) {
     throw err;
@@ -110,10 +110,8 @@ const logout = async (userId) => {
       throw new ApiError(StatusCodes.NOT_FOUND, `User with id '${userId}' not found`);
     }
 
-    await userModel.updateOneUserById(user.id, {
-      is_active: false,
-      last_active: new Date().toISOString()
-    });
+    // is_active/last_active are now driven by real Socket.IO presence
+    // (server/src/socket/index.js), not by login/logout requests.
 
     return userId;
   } catch (err) {

--- a/server/src/socket/index.js
+++ b/server/src/socket/index.js
@@ -1,11 +1,31 @@
 import { Server } from "socket.io";
 
 import authMiddleware from "../middlewares/auth-middleware.js";
+import userModel from "../api/models/user-model.js";
 import registerConversationHandlers from "./conversation-socket.js";
 import registerMessageHandlers from "./message-socket.js";
 import registerTaskCommentHandlers from "./task-comment-socket.js";
 
 let ioInstance = null;
+
+// Real presence tracking: userId -> Set<socketId> of currently-open connections.
+// A user is "online" as long as this set is non-empty (covers multiple open
+// tabs/devices). Going offline is debounced so a page refresh's brief
+// disconnect/reconnect doesn't flicker someone's status to everyone else.
+const connectionsByUser = new Map();
+const offlineTimers = new Map();
+const OFFLINE_GRACE_MS = 5000;
+
+const markUserOffline = (io, userId) => {
+  offlineTimers.delete(userId);
+
+  if (connectionsByUser.get(userId)?.size) return; // reconnected during the grace period
+
+  const lastActive = new Date().toISOString();
+
+  userModel.updateOneUserById(userId, { is_active: false, last_active: lastActive }).catch(() => {});
+  io.emit("user_status_changed", { user_id: userId, is_active: false, last_active: lastActive });
+};
 
 const setupSocket = (server) => {
   const io = new Server(server, {
@@ -21,14 +41,34 @@ const setupSocket = (server) => {
   io.use(authMiddleware.authenticateSocket);
 
   io.on("connection", (socket) => {
-    // console.log("A client connected: " + socket.id);
+    const userId = socket.data.user?.id;
+
+    if (userId) {
+      const pendingOfflineTimer = offlineTimers.get(userId);
+      if (pendingOfflineTimer) {
+        clearTimeout(pendingOfflineTimer);
+        offlineTimers.delete(userId);
+      }
+
+      const sockets = connectionsByUser.get(userId) ?? new Set();
+      const wasOffline = sockets.size === 0;
+      sockets.add(socket.id);
+      connectionsByUser.set(userId, sockets);
+
+      if (wasOffline) {
+        userModel.updateOneUserById(userId, { is_active: true }).catch(() => {});
+        io.emit("user_status_changed", { user_id: userId, is_active: true });
+      }
+    }
 
     socket.on("setup", () => {
       const userId = socket.data.user.id;
 
       if (userId) {
         socket.join(`user_${userId}`);
-        // console.log(`User ${userId} joined personal room`);
+        // Fresh connections need the full current snapshot; going forward
+        // they get incremental updates via "user_status_changed".
+        socket.emit("online_users", Array.from(connectionsByUser.keys()));
       }
     });
 
@@ -36,17 +76,22 @@ const setupSocket = (server) => {
     registerMessageHandlers(io, socket);
     registerTaskCommentHandlers(io, socket);
 
-    // socket.on("disconnect", (reason) => {
-    //   console.log(`Client disconnected: ${socket.id}, Reason: ${reason}`);
-    // });
+    socket.on("disconnect", () => {
+      if (!userId) return;
 
-    // socket.on("error", (error) => {
-    //   console.error("Socket Error on connection:", error);
-    // });
+      const sockets = connectionsByUser.get(userId);
+      if (!sockets) return;
 
-    // socket.on("connect_error", (error) => {
-    //   console.log(`connect_error due to ${error.message}`);
-    // });
+      sockets.delete(socket.id);
+
+      if (sockets.size === 0) {
+        connectionsByUser.delete(userId);
+        offlineTimers.set(
+          userId,
+          setTimeout(() => markUserOffline(io, userId), OFFLINE_GRACE_MS)
+        );
+      }
+    });
   });
 };
 


### PR DESCRIPTION
## Summary
- `is_active` was only ever flipped on /login and /logout requests — closing a tab (the common case) left a user "active" forever, and multi-tab users got marked inactive as soon as any one tab logged out.
- Replaced with real Socket.IO-connection-based presence tracking (reference-counted per user, 5s debounce on going offline to avoid refresh flicker), broadcast to all clients via `user_status_changed`/`online_users`.
- Shown as an online dot on direct-message avatars (chat header + conversation list) and as an Online/Offline badge + last-active time in the admin Users table.

## Test plan
- [ ] Manual: open the app in two browser profiles (two different users), confirm each sees the other's online dot in a DM and in admin Users
- [ ] Manual: close one tab, confirm the other side flips to offline within ~5s