### PR TITLE
fix: online dot clipping, former-member assignee crash, team-select race

### DIFF
--- a/client/src/components/chat/chat-header.jsx
+++ b/client/src/components/chat/chat-header.jsx
@@ -26,25 +26,27 @@ export default function ChatHeader() {
 
   return (
     <div className="flex w-full h-20 max-w-full gap-4 items-center border-b bg-white px-6 py-4">
-      <Avatar className="h-12 w-12 relative">
-        <AvatarImage
-          src={currConversation.avatar_url}
-          alt={currConversation.title}
-          className="object-cover"
-        />
-        <AvatarFallback style={pickAvatarColor(currConversation.title)}>
-          {currConversation.type === "direct" ? (
-            getInitials(currConversation.title)
-          ) : currConversation.type === "team" ? (
-            <Users />
-          ) : (
-            <FolderKanban />
-          )}
-        </AvatarFallback>
+      <div className="relative h-12 w-12 flex-none">
+        <Avatar className="h-12 w-12">
+          <AvatarImage
+            src={currConversation.avatar_url}
+            alt={currConversation.title}
+            className="object-cover"
+          />
+          <AvatarFallback style={pickAvatarColor(currConversation.title)}>
+            {currConversation.type === "direct" ? (
+              getInitials(currConversation.title)
+            ) : currConversation.type === "team" ? (
+              <Users />
+            ) : (
+              <FolderKanban />
+            )}
+          </AvatarFallback>
+        </Avatar>
         {currConversation.type === "direct" && onlineUserIds.has(currConversation.direct_user_id) && (
           <span className="absolute bottom-0 right-0 h-3 w-3 rounded-full bg-green-500 border-2 border-white" />
         )}
-      </Avatar>
+      </div>
       <div className="max-w-4/5">
         <div className="flex-none text-xl font-semibold truncate">
           {currConversation.title ||

--- a/client/src/components/chat/nav-conversation-item.jsx
+++ b/client/src/components/chat/nav-conversation-item.jsx
@@ -37,10 +37,10 @@ export default function NavConversationItem({ conversation }) {
               <FolderKanban />
             )}
           </AvatarFallback>
-          {conversation.type === "direct" && onlineUserIds.has(conversation.direct_user_id) && (
-            <span className="absolute bottom-0 right-0 h-3 w-3 rounded-full bg-green-500 border-2 border-white" />
-          )}
         </Avatar>
+        {conversation.type === "direct" && onlineUserIds.has(conversation.direct_user_id) && (
+          <span className="absolute bottom-0 right-0 h-3 w-3 rounded-full bg-green-500 border-2 border-white" />
+        )}
         {conversation.unread_count > 0 && (
           <Badge className="text-xs bg-prussian-blue absolute h-5 w-5 -bottom-1 -right-1 transform -translate-y-0.5 z-10">
             {conversation.unread_count < 10 ? conversation.unread_count : "9+"}

--- a/client/src/components/task/details/task-details-form.jsx
+++ b/client/src/components/task/details/task-details-form.jsx
@@ -29,6 +29,7 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useProject } from "@/hooks/use-project";
 import { cn, capitalCase, formatDateShort } from "@/lib/utils";
 import { getInitials, pickAvatarColor } from "@/lib/user-utils";
@@ -65,7 +66,7 @@ export default function TaskDetailsForm({ task, onSubmit, initialValues }) {
   const { projectMembers } = useProject();
 
   const availableMembers = projectMembers?.filter(
-    (member) => !task?.assignees.some((assignee) => assignee.id === member.id)
+    (member) => !task?.assignees.some((assignee) => assignee.user_id === member.id)
   );
 
   const form = useForm({
@@ -239,35 +240,62 @@ export default function TaskDetailsForm({ task, onSubmit, initialValues }) {
                         {field.value.length > 0 ? (
                           <div className="flex flex-wrap gap-2 w-full">
                             {field.value.map((assigneeId) => {
+                              // Prefer the live project-member record (current avatar/name),
+                              // but fall back to the task's own already-joined assignee data —
+                              // someone can still be assigned to a task after leaving the
+                              // project/team, and we keep that history rather than deleting it.
                               const member = projectMembers.find((m) => m.id === assigneeId);
+                              const assigneeRecord = task?.assignees.find(
+                                (a) => a.user_id === assigneeId
+                              );
+                              const fullName = member?.full_name ?? assigneeRecord?.full_name ?? "Unknown user";
+                              const avatarUrl = member?.avatar_url ?? assigneeRecord?.avatar_url;
+                              const hasLeftProject = !member;
 
-                              return (
+                              const chip = (
                                 <div
-                                  key={member.id}
-                                  className="flex items-center gap-2 px-2 py-1.5 rounded-md text-xs bg-mustard/50 max-w-2/5"
+                                  className={cn(
+                                    "flex items-center gap-2 px-2 py-1.5 rounded-md text-xs bg-mustard/50 max-w-2/5",
+                                    hasLeftProject && "opacity-50"
+                                  )}
                                 >
                                   <Avatar className="h-6 w-6">
                                     <AvatarImage
                                       className="object-cover"
-                                      src={member.avatar_url}
-                                      alt={member.full_name}
+                                      src={avatarUrl}
+                                      alt={fullName}
                                     />
-                                    <AvatarFallback style={pickAvatarColor(member.full_name)}>
-                                      {getInitials(member.full_name)}
+                                    <AvatarFallback style={pickAvatarColor(fullName)}>
+                                      {getInitials(fullName)}
                                     </AvatarFallback>
                                   </Avatar>
-                                  <span className="truncate">{member.full_name}</span>
+                                  <span className="truncate">{fullName}</span>
                                   <div
                                     className="h-4 w-4 p-0 hover:text-prussian-blue cursor-pointer"
                                     onClick={(e) => {
                                       e.preventDefault();
                                       e.stopPropagation();
-                                      field.onChange(field.value.filter((id) => id !== member.id));
+                                      field.onChange(field.value.filter((id) => id !== assigneeId));
                                     }}
                                   >
                                     <X className="h-4 w-4" />
                                   </div>
                                 </div>
+                              );
+
+                              if (!hasLeftProject) {
+                                return <div key={assigneeId}>{chip}</div>;
+                              }
+
+                              return (
+                                <TooltipProvider key={assigneeId}>
+                                  <Tooltip delayDuration={300}>
+                                    <TooltipTrigger asChild>{chip}</TooltipTrigger>
+                                    <TooltipContent side="top">
+                                      <p>No longer a project member</p>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                </TooltipProvider>
                               );
                             })}
                           </div>

--- a/client/src/hooks/use-team.js
+++ b/client/src/hooks/use-team.js
@@ -54,12 +54,16 @@ export function TeamProvider({ children }) {
     setSelectedTeamId(team?.id ?? null);
   }, []);
 
-  // Auto-select the first team once teams load, if none selected yet
+  // Auto-select the first team once teams load, if none selected yet.
+  // Uses a functional update (reads the latest state at apply-time, not this
+  // render's stale closure) so it can't clobber a team the URL just picked
+  // via setSelectedTeam in the same effect flush — a plain `!selectedTeamId`
+  // check here raced with TeamSelector's own effect and always lost to
+  // whichever ran second, regardless of what the URL said.
   useEffect(() => {
-    if (teams.length > 0 && !selectedTeamId) {
-      setSelectedTeamId(teams[0].id);
-    }
-  }, [teams, selectedTeamId]);
+    if (teams.length === 0) return;
+    setSelectedTeamId((prev) => (prev !== null ? prev : teams[0].id));
+  }, [teams]);
 
   const teamMembersQuery = useQuery({
     queryKey: ["team-members", selectedTeamId],


### PR DESCRIPTION
## Summary
- Online-status dot was clipped by Avatar's overflow-hidden/rounded-full — moved it outside Avatar into the wrapper div (chat header + conversation list).
- Opening/editing a task with an assignee who left the project crashed (`Cannot read properties of undefined (reading 'avatar_url')`). Chip renderer now falls back to the task's own joined assignee data and shows a dimmed chip + "No longer a project member" tooltip instead of crashing. Also fixed a wrong-field filter bug in the "available members" list.
- Reloading with `?team=<id>` in the URL could jump to a different team, after which re-selecting the intended team via the dropdown silently did nothing. Root cause: TeamProvider's auto-select-first-team effect raced with the URL-driven selection and clobbered it via a stale closure. Fixed with a functional state update.

## Test plan
- [ ] Manual: confirm the online dot renders as a full circle, not a clipped sliver
- [ ] Manual: open a task assigned to someone no longer in the project, confirm it shows a dimmed chip with a tooltip instead of crashing
- [ ] Manual: reload `/app/task?team=1` a few times, confirm it consistently lands on team 1 and switching teams via the dropdown always works