### PR TITLE
feat: exclusive row-action menus, dim former-member assignees everywhere

### DIFF
--- a/client/src/app/(app)/layout.jsx
+++ b/client/src/app/(app)/layout.jsx
@@ -11,6 +11,7 @@ import { ProjectProvider } from "@/hooks/use-project";
 import { TaskProvider } from "@/hooks/use-task";
 import { ChatProvider } from "@/hooks/use-chat";
 import { NotificationProvider } from "@/hooks/use-notification";
+import { ExclusiveMenuProvider } from "@/hooks/use-exclusive-menu";
 import { Toaster } from "sonner";
 
 export default async function RootLayout({ children }) {
@@ -26,15 +27,17 @@ export default async function RootLayout({ children }) {
               <ProjectProvider>
                 <TaskProvider>
                   <ChatProvider>
-                    <SidebarProvider defaultOpen={defaultOpen}>
-                      <SearchProvider>
-                        <AppSidebar variant="inset" />
-                        <SidebarInset>
-                          <main className="flex-1 min-h-[95dvh] bg-prussian-blue">{children}</main>
-                        </SidebarInset>
-                        <Toaster position="top-right" />
-                      </SearchProvider>
-                    </SidebarProvider>
+                    <ExclusiveMenuProvider>
+                      <SidebarProvider defaultOpen={defaultOpen}>
+                        <SearchProvider>
+                          <AppSidebar variant="inset" />
+                          <SidebarInset>
+                            <main className="flex-1 min-h-[95dvh] bg-prussian-blue">{children}</main>
+                          </SidebarInset>
+                          <Toaster position="top-right" />
+                        </SearchProvider>
+                      </SidebarProvider>
+                    </ExclusiveMenuProvider>
                   </ChatProvider>
                 </TaskProvider>
               </ProjectProvider>

--- a/client/src/components/admin/admin-project-actions.jsx
+++ b/client/src/components/admin/admin-project-actions.jsx
@@ -11,13 +11,15 @@ import {
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
+import { useExclusiveMenu } from "@/hooks/use-exclusive-menu";
 
 export default function AdminProjectActions({ project, listParams }) {
   const [isTransferDialogOpen, setIsTransferDialogOpen] = useState(false);
+  const menuProps = useExclusiveMenu();
 
   return (
     <div>
-      <DropdownMenu>
+      <DropdownMenu {...menuProps}>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="icon">
             <MoreHorizontal className="h-4 w-4" />

--- a/client/src/components/admin/admin-team-actions.jsx
+++ b/client/src/components/admin/admin-team-actions.jsx
@@ -11,13 +11,15 @@ import {
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
+import { useExclusiveMenu } from "@/hooks/use-exclusive-menu";
 
 export default function AdminTeamActions({ team, listParams }) {
   const [isTransferDialogOpen, setIsTransferDialogOpen] = useState(false);
+  const menuProps = useExclusiveMenu();
 
   return (
     <div>
-      <DropdownMenu>
+      <DropdownMenu {...menuProps}>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="icon">
             <MoreHorizontal className="h-4 w-4" />

--- a/client/src/components/admin/admin-user-actions.jsx
+++ b/client/src/components/admin/admin-user-actions.jsx
@@ -14,16 +14,18 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { useAdmin } from "@/hooks/use-admin";
+import { useExclusiveMenu } from "@/hooks/use-exclusive-menu";
 
 export default function AdminUserActions({ user, listParams }) {
   const { handleSetUserEnabled, handleResendPasswordReset } = useAdmin();
   const [isRoleDialogOpen, setIsRoleDialogOpen] = useState(false);
   const [isDisableDialogOpen, setIsDisableDialogOpen] = useState(false);
   const [isForceLogoutDialogOpen, setIsForceLogoutDialogOpen] = useState(false);
+  const menuProps = useExclusiveMenu();
 
   return (
     <div>
-      <DropdownMenu>
+      <DropdownMenu {...menuProps}>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="icon">
             <MoreHorizontal className="h-4 w-4" />

--- a/client/src/components/task/comments/comment-item.jsx
+++ b/client/src/components/task/comments/comment-item.jsx
@@ -15,11 +15,13 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useTaskComment } from "@/hooks/use-task-comment";
 import { useSession } from "@/hooks/use-session";
+import { useExclusiveMenu } from "@/hooks/use-exclusive-menu";
 import { getInitials, pickAvatarColor } from "@/lib/user-utils";
 
 export default function CommentItem({ comment }) {
   const { handleUpdateComment, handleDeleteComment } = useTaskComment();
   const { user } = useSession();
+  const menuProps = useExclusiveMenu();
 
   const [isEditing, setIsEditing] = useState(false);
   const [editContent, setEditContent] = useState(comment.content);
@@ -66,7 +68,7 @@ export default function CommentItem({ comment }) {
           </div>
 
           {comment.commenter_id === user.id && (
-            <DropdownMenu modal={false}>
+            <DropdownMenu modal={false} {...menuProps}>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="icon" className="h-4 w-4 bg-transparent">
                   <MoreHorizontal className="h-4 w-4" />

--- a/client/src/components/task/kanban/kanban-item.jsx
+++ b/client/src/components/task/kanban/kanban-item.jsx
@@ -1,12 +1,10 @@
 "use client";
 
 import TaskActions from "@/components/task/task-actions";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import TaskAssigneeAvatars from "@/components/task/task-assignee-avatars";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
-import { AvatarGroup } from "@/components/ui/avatar-group";
 import { Badge } from "@/components/ui/badge";
 import { pickPriorityColor } from "@/lib/task-utils";
-import { getInitials, pickAvatarColor } from "@/lib/user-utils";
 import { cn, formatDate, capitalCase } from "@/lib/utils";
 
 export default function KanbanItem({ task, columnId }) {
@@ -47,23 +45,7 @@ export default function KanbanItem({ task, columnId }) {
       <CardFooter className="px-4 pb-2 flex justify-between items-end">
         <div className="flex items-center gap-2">
           {task.assignees && task.assignees.length > 0 ? (
-            <AvatarGroup className="flex items-center justify-center -space-x-2.5">
-              {task.assignees.slice(0, 3).map((assignee) => (
-                <Avatar key={assignee.user_id} className="h-8 w-8 text-xs">
-                  <AvatarImage className="object-cover" src={assignee.avatar_url} />
-                  <AvatarFallback style={pickAvatarColor(assignee.full_name)}>
-                    {getInitials(assignee.full_name)}
-                  </AvatarFallback>
-                </Avatar>
-              ))}
-              {task.assignees.length > 3 && (
-                <Avatar className="h-8 w-8">
-                  <AvatarFallback className="text-xs font-medium bg-blue-100 text-prussian-blue">
-                    +{task.assignees.length - 3}
-                  </AvatarFallback>
-                </Avatar>
-              )}
-            </AvatarGroup>
+            <TaskAssigneeAvatars assignees={task.assignees} />
           ) : (
             <span className="h-6 w-6" />
           )}

--- a/client/src/components/task/list/task-list-column.jsx
+++ b/client/src/components/task/list/task-list-column.jsx
@@ -5,14 +5,12 @@ import { useState } from "react";
 import { ArrowUpDown, Clock, GripVertical, PanelRight } from "lucide-react";
 
 import TaskActions from "@/components/task/task-actions";
-import { AvatarGroup } from "@/components/ui/avatar-group";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import TaskAssigneeAvatars from "@/components/task/task-assignee-avatars";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { pickPriorityColor, pickStatusColor, comparePriority } from "@/lib/task-utils";
-import { getInitials, pickAvatarColor } from "@/lib/user-utils";
 import { cn, formatDateShort, capitalCase } from "@/lib/utils";
 
 export const getColumns = () => {
@@ -203,23 +201,7 @@ export const getColumns = () => {
         const task = row.original;
 
         return task.assignees.length > 0 ? (
-          <AvatarGroup className="flex items-center justify-center -space-x-2.5">
-            {task.assignees.slice(0, 3).map((assignee) => (
-              <Avatar key={assignee.user_id} className="h-8 w-8 text-xs">
-                <AvatarImage className="object-cover" src={assignee.avatar_url} />
-                <AvatarFallback style={pickAvatarColor(assignee.full_name)}>
-                  {getInitials(assignee.full_name)}
-                </AvatarFallback>
-              </Avatar>
-            ))}
-            {task.assignees.length > 3 && (
-              <Avatar className="h-8 w-8">
-                <AvatarFallback className="text-xs font-medium bg-blue-100 text-prussian-blue">
-                  +{task.assignees.length - 3}
-                </AvatarFallback>
-              </Avatar>
-            )}
-          </AvatarGroup>
+          <TaskAssigneeAvatars assignees={task.assignees} />
         ) : (
           <div className="text-center text-sm text-muted-foreground">-</div>
         );

--- a/client/src/components/task/task-actions.jsx
+++ b/client/src/components/task/task-actions.jsx
@@ -13,9 +13,11 @@ import {
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
+import { useExclusiveMenu } from "@/hooks/use-exclusive-menu";
 
 export default function TaskActions({ task }) {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const menuProps = useExclusiveMenu();
 
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -28,7 +30,7 @@ export default function TaskActions({ task }) {
 
   return (
     <div>
-      <DropdownMenu className="dropdown-menu-selector">
+      <DropdownMenu {...menuProps} className="dropdown-menu-selector">
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="sm">
             <MoreVertical className="h-4 w-4" />

--- a/client/src/components/task/task-assignee-avatars.jsx
+++ b/client/src/components/task/task-assignee-avatars.jsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { AvatarGroup } from "@/components/ui/avatar-group";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useProject } from "@/hooks/use-project";
+import { getInitials, pickAvatarColor } from "@/lib/user-utils";
+
+export default function TaskAssigneeAvatars({ assignees }) {
+  const { projectMembers } = useProject();
+
+  if (!assignees || assignees.length === 0) {
+    return null;
+  }
+
+  return (
+    <AvatarGroup className="flex items-center justify-center -space-x-2.5">
+      {assignees.slice(0, 3).map((assignee) => {
+        const hasLeftProject = !projectMembers?.some((m) => m.id === assignee.user_id);
+
+        if (!hasLeftProject) {
+          return (
+            <Avatar key={assignee.user_id} className="h-8 w-8 text-xs">
+              <AvatarImage className="object-cover" src={assignee.avatar_url} />
+              <AvatarFallback style={pickAvatarColor(assignee.full_name)}>
+                {getInitials(assignee.full_name)}
+              </AvatarFallback>
+            </Avatar>
+          );
+        }
+
+        return (
+          <TooltipProvider key={assignee.user_id}>
+            <Tooltip delayDuration={300}>
+              <TooltipTrigger asChild>
+                <Avatar className="h-8 w-8 text-xs opacity-50">
+                  <AvatarImage className="object-cover" src={assignee.avatar_url} />
+                  <AvatarFallback style={pickAvatarColor(assignee.full_name)}>
+                    {getInitials(assignee.full_name)}
+                  </AvatarFallback>
+                </Avatar>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                <p>No longer a project member</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        );
+      })}
+      {assignees.length > 3 && (
+        <Avatar className="h-8 w-8">
+          <AvatarFallback className="text-xs font-medium bg-blue-100 text-prussian-blue">
+            +{assignees.length - 3}
+          </AvatarFallback>
+        </Avatar>
+      )}
+    </AvatarGroup>
+  );
+}

--- a/client/src/components/team/actions/project-actions.jsx
+++ b/client/src/components/team/actions/project-actions.jsx
@@ -12,14 +12,16 @@ import {
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
+import { useExclusiveMenu } from "@/hooks/use-exclusive-menu";
 
 export default function ProjectActions({ project }) {
   const [isDetailsSheetOpen, setIsDetailsSheetOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const menuProps = useExclusiveMenu();
 
   return (
     <div>
-      <DropdownMenu>
+      <DropdownMenu {...menuProps}>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="icon">
             <MoreVertical className="h-4 w-4" />

--- a/client/src/components/team/actions/project-member-actions.jsx
+++ b/client/src/components/team/actions/project-member-actions.jsx
@@ -12,14 +12,16 @@ import {
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
+import { useExclusiveMenu } from "@/hooks/use-exclusive-menu";
 
 export default function ProjectMemberActions({ member }) {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const menuProps = useExclusiveMenu();
 
   return (
     <div>
-      <DropdownMenu>
+      <DropdownMenu {...menuProps}>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="icon">
             <MoreHorizontal className="h-4 w-4" />

--- a/client/src/components/team/actions/team-actions.jsx
+++ b/client/src/components/team/actions/team-actions.jsx
@@ -13,15 +13,17 @@ import {
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
+import { useExclusiveMenu } from "@/hooks/use-exclusive-menu";
 
 export default function TeamActions({ team }) {
   const [isDetailsSheetOpen, setIsDetailsSheetOpen] = useState(false);
   const [isLeaveDialogOpen, setIsLeaveDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const menuProps = useExclusiveMenu();
 
   return (
     <div>
-      <DropdownMenu>
+      <DropdownMenu {...menuProps}>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="icon">
             <MoreVertical className="h-4 w-4" />

--- a/client/src/components/team/actions/team-member-actions.jsx
+++ b/client/src/components/team/actions/team-member-actions.jsx
@@ -12,14 +12,16 @@ import {
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
+import { useExclusiveMenu } from "@/hooks/use-exclusive-menu";
 
 export default function TeamMemberActions({ member }) {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const menuProps = useExclusiveMenu();
 
   return (
     <div>
-      <DropdownMenu>
+      <DropdownMenu {...menuProps}>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="icon">
             <MoreHorizontal className="h-4 w-4" />

--- a/client/src/components/team/actions/team-project-actions.jsx
+++ b/client/src/components/team/actions/team-project-actions.jsx
@@ -12,13 +12,15 @@ import {
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
+import { useExclusiveMenu } from "@/hooks/use-exclusive-menu";
 
 export default function TeamProjectActions({ project }) {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const menuProps = useExclusiveMenu();
 
   return (
     <div>
-      <DropdownMenu>
+      <DropdownMenu {...menuProps}>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="icon">
             <MoreHorizontal className="h-4 w-4" />

--- a/client/src/hooks/use-exclusive-menu.js
+++ b/client/src/hooks/use-exclusive-menu.js
@@ -1,0 +1,32 @@
+"use client";
+
+import { createContext, useContext, useId, useState } from "react";
+
+const ExclusiveMenuContext = createContext(null);
+
+export function ExclusiveMenuProvider({ children }) {
+  const [openId, setOpenId] = useState(null);
+
+  return (
+    <ExclusiveMenuContext.Provider value={{ openId, setOpenId }}>
+      {children}
+    </ExclusiveMenuContext.Provider>
+  );
+}
+
+// Coordinates row-action dropdown menus (and similar popovers) so opening one
+// automatically closes whatever else was open, anywhere in the app. Spread
+// the returned props onto a Radix DropdownMenu/Popover root to opt it in.
+export function useExclusiveMenu() {
+  const ctx = useContext(ExclusiveMenuContext);
+  const id = useId();
+
+  if (!ctx) return {};
+
+  const { openId, setOpenId } = ctx;
+
+  return {
+    open: openId === id,
+    onOpenChange: (next) => setOpenId(next ? id : null)
+  };
+}


### PR DESCRIPTION
## Summary
- Row-action "..." dropdown menus (team/project members, tasks, admin users/teams/projects, task comments) were each an independently uncontrolled DropdownMenu, so multiple rows across a table could have their menu open simultaneously. Added a shared `ExclusiveMenuProvider`/`useExclusiveMenu()` coordinator so opening one always closes whatever else was open.
- The former-project-member dimming added earlier only applied in the task detail form's assignee picker. Extracted a shared `TaskAssigneeAvatars` component and applied the same dimmed-avatar + tooltip treatment to the Kanban card and task list table's Assignees column.

## Test plan
- [ ] Manual: open the "..." menu on one row, then another row in the same table — confirm the first one closes automatically
- [ ] Manual: confirm this holds across different tables (team members, admin users, task list, etc.)
- [ ] Manual: view a task's Kanban card / list row where an assignee left the project — confirm the avatar shows dimmed with a tooltip, not just in the detail sheet