### PR TITLE
feat(admin): visual refresh for Dashboard and Health tabs

### DIFF
--- a/client/src/components/admin/admin-dashboard.jsx
+++ b/client/src/components/admin/admin-dashboard.jsx
@@ -1,22 +1,28 @@
 "use client";
 
 import { useEffect } from "react";
+import Link from "next/link";
+import { usePathname, useSearchParams } from "next/navigation";
 import { Users, UsersRound, FolderKanban, ListChecks } from "lucide-react";
 
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import Sparkline from "@/components/admin/sparkline";
+import { cn, capitalCase } from "@/lib/utils";
 import { useAdmin } from "@/hooks/use-admin";
 
-const STATUS_DOT = {
-  up: "bg-green-500",
-  ready: "bg-green-500",
-  down: "bg-red-500",
-  failed: "bg-red-500",
-  initializing: "bg-amber-500"
+const STATUS_BADGE = {
+  up: "bg-green-100 text-green-700",
+  ready: "bg-green-100 text-green-700",
+  down: "bg-red-100 text-red-700",
+  failed: "bg-red-100 text-red-700",
+  initializing: "bg-amber-100 text-amber-700"
 };
 
 export default function AdminDashboard() {
   const { stats, health, fetchStats, fetchHealth } = useAdmin();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
 
   useEffect(() => {
     fetchStats();
@@ -24,44 +30,86 @@ export default function AdminDashboard() {
   }, [fetchStats, fetchHealth]);
 
   const cards = [
-    { label: "Users", value: stats?.user_count, icon: Users },
-    { label: "Teams", value: stats?.team_count, icon: UsersRound },
-    { label: "Projects", value: stats?.project_count, icon: FolderKanban },
-    { label: "Tasks", value: stats?.task_count, icon: ListChecks }
+    {
+      label: "Users",
+      value: stats?.user_count,
+      trend: stats?.history?.users,
+      icon: Users,
+      iconClass: "bg-blue-100 text-blue-700"
+    },
+    {
+      label: "Teams",
+      value: stats?.team_count,
+      trend: stats?.history?.teams,
+      icon: UsersRound,
+      iconClass: "bg-emerald-100 text-emerald-700"
+    },
+    {
+      label: "Projects",
+      value: stats?.project_count,
+      trend: stats?.history?.projects,
+      icon: FolderKanban,
+      iconClass: "bg-amber-100 text-amber-700"
+    },
+    {
+      label: "Tasks",
+      value: stats?.task_count,
+      trend: stats?.history?.tasks,
+      icon: ListChecks,
+      iconClass: "bg-mustard/40 text-prussian-blue"
+    }
   ];
 
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        {cards.map(({ label, value, icon: Icon }) => (
-          <Card key={label}>
-            <CardHeader className="flex flex-row items-center justify-between">
-              <CardTitle className="text-sm font-medium text-muted-foreground">{label}</CardTitle>
-              <Icon className="h-4 w-4 text-prussian-blue" />
+        {cards.map(({ label, value, trend, icon: Icon, iconClass }) => (
+          <Card key={label} className="gap-3">
+            <CardHeader className="flex flex-row items-start justify-between">
+              <div>
+                <CardTitle className="text-sm font-medium text-muted-foreground">{label}</CardTitle>
+                <p className="text-3xl font-bold mt-1">{value ?? "—"}</p>
+              </div>
+              <div className={cn("flex-none rounded-lg p-2", iconClass)}>
+                <Icon className="h-4 w-4" />
+              </div>
             </CardHeader>
             <CardContent>
-              <p className="text-2xl font-bold">{value ?? "—"}</p>
+              {trend && trend.length > 1 ? (
+                <Sparkline data={trend} className="h-8 w-full" />
+              ) : (
+                <div className="h-8" />
+              )}
             </CardContent>
           </Card>
         ))}
       </div>
 
       <Card>
-        <CardHeader>
+        <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle className="text-sm font-medium text-muted-foreground">
             System Health
           </CardTitle>
+          <Link
+            href={`${pathname}?${new URLSearchParams({
+              ...Object.fromEntries(searchParams),
+              tab: "health"
+            }).toString()}`}
+            className="text-xs font-semibold text-blue-green hover:underline"
+          >
+            View details →
+          </Link>
         </CardHeader>
         <CardContent>
           {health?.dependencies?.length ? (
-            <div className="flex flex-row flex-wrap gap-4">
+            <div className="flex flex-row flex-wrap gap-2">
               {health.dependencies.map((dep) => (
-                <div key={dep.name} className="flex items-center gap-2">
-                  <span
-                    className={cn("h-2.5 w-2.5 rounded-full", STATUS_DOT[dep.status] ?? "bg-gray-400")}
-                  />
-                  <span className="text-sm capitalize">{dep.name}</span>
-                </div>
+                <Badge
+                  key={dep.name}
+                  className={cn("rounded-sm capitalize", STATUS_BADGE[dep.status] ?? "bg-gray-100 text-gray-700")}
+                >
+                  {capitalCase(dep.name)}
+                </Badge>
               ))}
             </div>
           ) : (

--- a/client/src/components/admin/admin-health-panel.jsx
+++ b/client/src/components/admin/admin-health-panel.jsx
@@ -1,7 +1,19 @@
 "use client";
 
 import { useEffect } from "react";
-import { RefreshCw } from "lucide-react";
+import {
+  RefreshCw,
+  Database,
+  HardDrive,
+  Mail,
+  BrainCircuit,
+  Radio,
+  Activity,
+  Clock,
+  MemoryStick,
+  Gauge,
+  AlertTriangle
+} from "lucide-react";
 
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -17,6 +29,15 @@ const STATUS_BADGE = {
   initializing: "bg-amber-100 text-amber-700"
 };
 
+const DEP_ICON = {
+  database: Database,
+  storage: HardDrive,
+  mail: Mail,
+  embedding: BrainCircuit
+};
+
+const isHealthy = (status) => status === "up" || status === "ready";
+
 function formatUptime(seconds) {
   if (seconds == null) return "—";
   const h = Math.floor(seconds / 3600);
@@ -31,9 +52,49 @@ export default function AdminHealthPanel() {
     fetchHealth();
   }, [fetchHealth]);
 
+  const deps = health?.dependencies ?? [];
+  const downDeps = deps.filter((dep) => !isHealthy(dep.status));
+  const allHealthy = deps.length > 0 && downDeps.length === 0;
+
   return (
     <div className="space-y-4">
       {error && <p className="text-sm text-red-500">{error.message}</p>}
+
+      {deps.length > 0 && (
+        <div
+          className={cn(
+            "flex items-center justify-between gap-4 rounded-xl p-6 text-white",
+            allHealthy ? "bg-prussian-blue" : "bg-gradient-to-br from-prussian-blue to-red-900"
+          )}
+        >
+          <div>
+            <p className="text-xs uppercase tracking-wide text-sky-blue font-semibold mb-1">
+              System status
+            </p>
+            <h3 className="text-lg font-semibold mb-1">
+              {allHealthy
+                ? "All systems operational"
+                : `${downDeps.length} issue${downDeps.length > 1 ? "s" : ""} detected`}
+            </h3>
+            <p className="text-sm text-white/70">
+              {allHealthy
+                ? "Every monitored dependency is responding normally."
+                : `${downDeps.map((dep) => capitalCase(dep.name)).join(", ")} ${
+                    downDeps.length > 1 ? "are" : "is"
+                  } unreachable — everything else is operating normally.`}
+            </p>
+          </div>
+          <Badge
+            className={cn(
+              "flex-none rounded-full px-3 py-1 text-xs font-semibold",
+              allHealthy ? "bg-white/15 text-white" : "bg-mustard/90 text-prussian-blue"
+            )}
+          >
+            {deps.length - downDeps.length} of {deps.length} up
+          </Badge>
+        </div>
+      )}
+
       <div className="flex justify-end">
         <Button
           variant="outline"
@@ -48,47 +109,97 @@ export default function AdminHealthPanel() {
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {health?.dependencies?.map((dep) => (
-          <Card key={dep.name}>
-            <CardHeader className="flex flex-row items-center justify-between">
-              <CardTitle className="text-sm font-medium capitalize">{dep.name}</CardTitle>
-              <Badge className={cn("rounded-sm", STATUS_BADGE[dep.status] ?? "bg-gray-100 text-gray-700")}>
-                {capitalCase(dep.status)}
-              </Badge>
-            </CardHeader>
-            <CardContent className="space-y-1">
-              {dep.latency_ms != null && (
-                <p className="text-sm text-muted-foreground">Latency: {dep.latency_ms}ms</p>
-              )}
-              {dep.error && <p className="text-sm text-red-500">{dep.error}</p>}
-            </CardContent>
-          </Card>
-        ))}
+        {deps.map((dep) => {
+          const Icon = DEP_ICON[dep.name] ?? Activity;
+          const healthy = isHealthy(dep.status);
+
+          return (
+            <Card key={dep.name}>
+              <CardHeader className="flex flex-row items-center gap-3">
+                <div
+                  className={cn(
+                    "flex-none rounded-lg p-2",
+                    healthy ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"
+                  )}
+                >
+                  <Icon className="h-4 w-4" />
+                </div>
+                <CardTitle className="flex-1 text-sm font-medium capitalize">{dep.name}</CardTitle>
+                <Badge className={cn("rounded-sm", STATUS_BADGE[dep.status] ?? "bg-gray-100 text-gray-700")}>
+                  {capitalCase(dep.status)}
+                </Badge>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {dep.latency_ms != null && (
+                  <>
+                    <div className="flex justify-between text-xs text-muted-foreground">
+                      <span>Latency</span>
+                      <span>{dep.latency_ms}ms</span>
+                    </div>
+                    <div className="h-1.5 overflow-hidden rounded-full bg-gray-100">
+                      <div
+                        className={cn("h-full rounded-full", healthy ? "bg-green-500" : "bg-red-500")}
+                        style={{ width: `${Math.min((dep.latency_ms / 1000) * 100, 100)}%` }}
+                      />
+                    </div>
+                  </>
+                )}
+                {dep.error && (
+                  <div className="flex items-center gap-2 rounded-md bg-red-50 px-2.5 py-2 text-xs text-red-600">
+                    <AlertTriangle className="h-3.5 w-3.5 flex-none" />
+                    {dep.error}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          );
+        })}
 
         <Card>
-          <CardHeader>
+          <CardHeader className="flex flex-row items-center gap-3">
+            <div className="flex-none rounded-lg p-2 bg-sky-blue/30 text-blue-green">
+              <Radio className="h-4 w-4" />
+            </div>
             <CardTitle className="text-sm font-medium">Socket</CardTitle>
           </CardHeader>
           <CardContent>
             <p className="text-sm text-muted-foreground">
-              Connections: {health?.socket?.connections ?? "—"}
+              <span className="font-semibold text-foreground">
+                {health?.socket?.connections ?? "—"}
+              </span>{" "}
+              active connections
             </p>
           </CardContent>
         </Card>
 
         <Card>
-          <CardHeader>
+          <CardHeader className="flex flex-row items-center gap-3">
+            <div className="flex-none rounded-lg p-2 bg-sky-blue/30 text-blue-green">
+              <Activity className="h-4 w-4" />
+            </div>
             <CardTitle className="text-sm font-medium">Process</CardTitle>
           </CardHeader>
-          <CardContent className="space-y-1">
-            <p className="text-sm text-muted-foreground">
-              Uptime: {formatUptime(health?.process?.uptime_seconds)}
+          <CardContent className="space-y-1.5">
+            <p className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Clock className="h-3.5 w-3.5 text-blue-green" />
+              Uptime{" "}
+              <span className="font-semibold text-foreground">
+                {formatUptime(health?.process?.uptime_seconds)}
+              </span>
             </p>
-            <p className="text-sm text-muted-foreground">
-              Memory: {health?.process?.memory_mb != null ? `${health.process.memory_mb} MB` : "—"}
+            <p className="flex items-center gap-2 text-sm text-muted-foreground">
+              <MemoryStick className="h-3.5 w-3.5 text-blue-green" />
+              Memory{" "}
+              <span className="font-semibold text-foreground">
+                {health?.process?.memory_mb != null ? `${health.process.memory_mb} MB` : "—"}
+              </span>
             </p>
-            <p className="text-sm text-muted-foreground">
-              Load average: {health?.process?.load_avg?.join(", ") ?? "—"}
+            <p className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Gauge className="h-3.5 w-3.5 text-blue-green" />
+              Load avg{" "}
+              <span className="font-semibold text-foreground">
+                {health?.process?.load_avg?.join(", ") ?? "—"}
+              </span>
             </p>
           </CardContent>
         </Card>

--- a/client/src/components/admin/sparkline.jsx
+++ b/client/src/components/admin/sparkline.jsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useId } from "react";
+
+export default function Sparkline({ data, className, color = "var(--color-blue-green)" }) {
+  if (!data || data.length < 2) return null;
+
+  const width = 100;
+  const height = 32;
+  const padding = 3;
+  const max = Math.max(...data);
+  const min = Math.min(...data);
+  const range = max - min || 1;
+  const step = (width - padding * 2) / (data.length - 1);
+
+  const points = data.map((value, i) => [
+    padding + i * step,
+    height - padding - ((value - min) / range) * (height - padding * 2)
+  ]);
+
+  const linePath = `M ${points.map((p) => p.join(",")).join(" L ")}`;
+  const areaPath = `${linePath} L ${width - padding},${height} L ${padding},${height} Z`;
+  const [lastX, lastY] = points[points.length - 1];
+  const gradientId = useId();
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none" className={className}>
+      <defs>
+        <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor={color} stopOpacity="0.35" />
+          <stop offset="1" stopColor={color} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <path d={areaPath} fill={`url(#${gradientId})`} />
+      <path
+        d={linePath}
+        fill="none"
+        stroke={color}
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx={lastX} cy={lastY} r="2.4" fill={color} />
+    </svg>
+  );
+}

--- a/server/src/api/models/project-model.js
+++ b/server/src/api/models/project-model.js
@@ -127,6 +127,14 @@ const countProjects = async (q) => {
   }
 };
 
+const getAllCreatedAtTimestamps = async () => {
+  try {
+    return await db("projects").select("created_at");
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
 const isUserInProject = async (project_id, user_id) => {
   try {
     const [record] = await db("project_members")
@@ -247,6 +255,7 @@ export default {
   getManyProjectsByUserId,
   getManyProjectsPaginated,
   countProjects,
+  getAllCreatedAtTimestamps,
   isUserInProject,
   updateOneProjectById,
   deleteOneProjectById,

--- a/server/src/api/models/task-model.js
+++ b/server/src/api/models/task-model.js
@@ -219,6 +219,14 @@ const countTasks = async () => {
   }
 };
 
+const getAllCreatedAtTimestamps = async () => {
+  try {
+    return await db("tasks").select("created_at");
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
 const getMaxTaskPositionOfProject = async (project_id) => {
   try {
     const [{ max }] = await db("tasks").where({ project_id }).max("position AS max");
@@ -261,6 +269,7 @@ export default {
   getManyTasksByProjectId,
   getAssignedTasksByUserId,
   countTasks,
+  getAllCreatedAtTimestamps,
   updateOneTaskById,
   deleteOneTaskById,
   getAssigneesOfTask,

--- a/server/src/api/models/team-model.js
+++ b/server/src/api/models/team-model.js
@@ -111,6 +111,14 @@ const countTeams = async (q) => {
   }
 };
 
+const getAllCreatedAtTimestamps = async () => {
+  try {
+    return await db("teams").select("created_at");
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
 const isUserInTeam = async (team_id, user_id) => {
   const [record] = await db("team_members").where({ team_id, user_id }).limit(1);
 
@@ -278,6 +286,7 @@ export default {
   getManyTeamsByUserId,
   getManyTeamsPaginated,
   countTeams,
+  getAllCreatedAtTimestamps,
   isUserInTeam,
   updateOneTeamById,
   deleteOneTeamById,

--- a/server/src/api/models/user-model.js
+++ b/server/src/api/models/user-model.js
@@ -91,6 +91,14 @@ const countUsers = async (q) => {
   }
 };
 
+const getAllCreatedAtTimestamps = async () => {
+  try {
+    return await db("users").select("created_at");
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
 const updateOneUserById = async (id, updateData) => {
   try {
     const finalUpdate = {
@@ -133,6 +141,7 @@ export default {
   getAllUsers,
   getManyUsersPaginated,
   countUsers,
+  getAllCreatedAtTimestamps,
   updateOneUserById,
   deleteOneUserById
 };

--- a/server/src/api/services/admin-service.js
+++ b/server/src/api/services/admin-service.js
@@ -300,20 +300,43 @@ const transferProjectOwnership = async (projectId, newOwnerUserId) => {
   }
 };
 
+// Turns a list of { created_at } rows into an N-point cumulative growth curve
+// (how many existed at each of N evenly-spaced points between the first
+// record and now), for the dashboard's stat-card sparklines.
+const buildGrowthTrend = (rows, points = 8) => {
+  if (!rows.length) return Array(points).fill(0);
+
+  const timestamps = rows.map((r) => new Date(r.created_at).getTime()).sort((a, b) => a - b);
+  const start = timestamps[0];
+  const end = Date.now();
+  const step = Math.max(end - start, 1) / (points - 1);
+
+  return Array.from({ length: points }, (_, i) => {
+    const boundary = start + step * i;
+    return timestamps.filter((t) => t <= boundary).length;
+  });
+};
+
 const getSystemStats = async () => {
   try {
-    const [userCount, teamCount, projectCount, taskCount] = await Promise.all([
-      userModel.countUsers(),
-      teamModel.countTeams(),
-      projectModel.countProjects(),
-      taskModel.countTasks()
+    const [users, teams, projects, tasks] = await Promise.all([
+      userModel.getAllCreatedAtTimestamps(),
+      teamModel.getAllCreatedAtTimestamps(),
+      projectModel.getAllCreatedAtTimestamps(),
+      taskModel.getAllCreatedAtTimestamps()
     ]);
 
     return {
-      user_count: userCount,
-      team_count: teamCount,
-      project_count: projectCount,
-      task_count: taskCount
+      user_count: users.length,
+      team_count: teams.length,
+      project_count: projects.length,
+      task_count: tasks.length,
+      history: {
+        users: buildGrowthTrend(users),
+        teams: buildGrowthTrend(teams),
+        projects: buildGrowthTrend(projects),
+        tasks: buildGrowthTrend(tasks)
+      }
     };
   } catch (err) {
     throw err;


### PR DESCRIPTION
## Summary
Visual refresh of the two most "empty-looking" admin tabs, following an approved mockup:

- **Dashboard**: icon medallions on stat cards + a real growth sparkline per stat (cumulative count derived from actual created_at history, not decorative fake data). System Health summary now uses status badges instead of plain dots.
- **Health**: a status hero banner summarizing overall system state, per-dependency icons, latency as a proportional gauge bar, and the error message rendered as a proper alert box.
- Backend: `getSystemStats` now returns a lightweight growth history per entity alongside the count, computed from existing `created_at` columns (no new heavy queries).

## Test plan
- [ ] Manual: visit Admin > Dashboard, confirm icons + sparklines render and trend upward for Tasks
- [ ] Manual: visit Admin > Health, confirm the hero banner reflects the actual Mail-down state and latency bars scale sensibly