### PR TITLE
style(PR2/8): flatten dashboard cards and chart tooltips

### DIFF
--- a/client/src/components/dashboard/priority-card.jsx
+++ b/client/src/components/dashboard/priority-card.jsx
@@ -5,7 +5,7 @@ import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card";
 
 export default function PriorityCard() {
   return (
-    <Card className="h-full flex flex-col overflow-hidden bg-white">
+    <Card className="h-full flex flex-col overflow-hidden">
       <CardHeader className="flex-shrink-0 flex flex-row items-center justify-between space-y-0">
         <CardTitle className="text-xl m-0 p-0">Priority Distribution</CardTitle>
       </CardHeader>

--- a/client/src/components/dashboard/priority-chart.jsx
+++ b/client/src/components/dashboard/priority-chart.jsx
@@ -66,7 +66,7 @@ export default function PriorityChart() {
     if (!active || !payload || !payload.length) return null;
 
     return (
-      <div className="bg-white p-4 rounded-lg shadow-lg border">
+      <div className="bg-white p-4 rounded-lg border">
         <p className="font-medium mb-2">{label} Priority</p>
         <div className="space-y-1">
           <p className="flex items-center justify-between gap-4">

--- a/client/src/components/dashboard/progress-card.jsx
+++ b/client/src/components/dashboard/progress-card.jsx
@@ -5,7 +5,7 @@ import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card";
 
 export default function ProgressCard() {
   return (
-    <Card className="h-full flex flex-col overflow-hidden bg-white">
+    <Card className="h-full flex flex-col overflow-hidden">
       <CardHeader className="flex-shrink-0 flex flex-row items-center justify-between space-y-0">
         <CardTitle className="text-xl m-0 p-0">Completion Progress</CardTitle>
       </CardHeader>

--- a/client/src/components/dashboard/summary-card.jsx
+++ b/client/src/components/dashboard/summary-card.jsx
@@ -5,7 +5,7 @@ import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card";
 
 export default function SummaryCard() {
   return (
-    <Card className="h-full flex flex-col overflow-hidden bg-white">
+    <Card className="h-full flex flex-col overflow-hidden">
       <CardHeader className="flex-shrink-0 flex flex-row items-center justify-between space-y-0">
         <CardTitle className="text-xl m-0 p-0">Weekly Summary</CardTitle>
       </CardHeader>

--- a/client/src/components/dashboard/summary-chart.jsx
+++ b/client/src/components/dashboard/summary-chart.jsx
@@ -104,7 +104,7 @@ export default function SummaryChart() {
         <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
         <XAxis dataKey="date" tick={{ fontSize: 12 }} tickMargin={10} />
         <YAxis allowDecimals={false} tick={{ fontSize: 12 }} tickMargin={10} />
-        <ChartTooltip content={<ChartTooltipContent className="bg-white p-4 space-y-2" />} />
+        <ChartTooltip content={<ChartTooltipContent className="p-4 space-y-2" />} />
         <ChartLegend content={<ChartLegendContent />} />
         <Line
           type="monotone"

--- a/client/src/components/dashboard/workload-card.jsx
+++ b/client/src/components/dashboard/workload-card.jsx
@@ -5,7 +5,7 @@ import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card";
 
 export default function WorkloadCard() {
   return (
-    <Card className="h-full flex flex-col overflow-hidden bg-white">
+    <Card className="h-full flex flex-col overflow-hidden">
       <CardHeader className="flex-shrink-0 flex flex-row items-center justify-between space-y-0">
         <CardTitle className="text-xl m-0 p-0">Workload By Person</CardTitle>
       </CardHeader>

--- a/client/src/components/dashboard/workload-chart.jsx
+++ b/client/src/components/dashboard/workload-chart.jsx
@@ -117,7 +117,7 @@ export default function WorkloadChart() {
 
     const data = payload[0].payload;
     return (
-      <div className="bg-white p-4 rounded-lg shadow-lg border">
+      <div className="bg-white p-4 rounded-lg border">
         <p className="font-medium mb-2">{data.name}</p>
         <div className="space-y-1">
           <p className="flex items-center justify-between gap-4">


### PR DESCRIPTION
## Summary
Second of 8 PRs unifying the app's visual style to flat/white/gray-border.

- Removed redundant explicit `bg-white` from the 4 dashboard summary cards (Priority, Progress, Workload, Summary) — `Card`'s own token already resolves to white.
- Removed `shadow-lg` from the two hand-rolled chart tooltips (priority-chart, workload-chart) and a redundant `bg-white` override on summary-chart's shared tooltip.

## Test plan
- [ ] Manual: Dashboard tab — confirm the 4 chart cards and their hover tooltips look flat and consistent