### PR TITLE
style(PR3/8): clean up redundant shadow-none in team/admin windows

### DIFF
--- a/client/src/components/admin/admin-window.jsx
+++ b/client/src/components/admin/admin-window.jsx
@@ -28,31 +28,31 @@ export default function AdminWindow() {
         <TabsList className="justify-start w-full px-6 gap-x-6 rounded-none border-b bg-white">
           <TabsTrigger
             value="dashboard"
-            className="flex-none p-0 text-sm text-gray-500 rounded-none shadow-none data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:shadow-none"
+            className="flex-none p-0 text-sm text-gray-500 rounded-none data-[state=active]:bg-white data-[state=active]:text-black"
           >
             Dashboard
           </TabsTrigger>
           <TabsTrigger
             value="users"
-            className="flex-none p-0 text-sm text-gray-500 rounded-none shadow-none data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:shadow-none"
+            className="flex-none p-0 text-sm text-gray-500 rounded-none data-[state=active]:bg-white data-[state=active]:text-black"
           >
             Users
           </TabsTrigger>
           <TabsTrigger
             value="teams"
-            className="flex-none p-0 text-sm text-gray-500 rounded-none shadow-none data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:shadow-none"
+            className="flex-none p-0 text-sm text-gray-500 rounded-none data-[state=active]:bg-white data-[state=active]:text-black"
           >
             Teams
           </TabsTrigger>
           <TabsTrigger
             value="projects"
-            className="flex-none p-0 text-sm text-gray-500 rounded-none shadow-none data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:shadow-none"
+            className="flex-none p-0 text-sm text-gray-500 rounded-none data-[state=active]:bg-white data-[state=active]:text-black"
           >
             Projects
           </TabsTrigger>
           <TabsTrigger
             value="health"
-            className="flex-none p-0 text-sm text-gray-500 rounded-none shadow-none data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:shadow-none"
+            className="flex-none p-0 text-sm text-gray-500 rounded-none data-[state=active]:bg-white data-[state=active]:text-black"
           >
             Health
           </TabsTrigger>

--- a/client/src/components/team/project-manage/project-information-card.jsx
+++ b/client/src/components/team/project-manage/project-information-card.jsx
@@ -10,7 +10,7 @@ export default function ProjectInformationCard() {
   if (!selectedProject) return null;
 
   return (
-    <Card className="w-full gap-2 rounded-md shadow-none">
+    <Card className="w-full gap-2 rounded-md">
       <CardHeader>
         <div className="flex flex-row justify-between items-start">
           <div>

--- a/client/src/components/team/project-manage/project-manage-window.jsx
+++ b/client/src/components/team/project-manage/project-manage-window.jsx
@@ -29,7 +29,7 @@ export default function ProjectManageWindow({ teamId, projectId }) {
             <TabsList className="justify-start w-full px-6 gap-x-4 rounded-none border-b bg-white">
               <TabsTrigger
                 value="members"
-                className="flex-none p-0 text-sm text-gray-500 rounded-none shadow-none data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:shadow-none"
+                className="flex-none p-0 text-sm text-gray-500 rounded-none data-[state=active]:bg-white data-[state=active]:text-black"
               >
                 Members
               </TabsTrigger>

--- a/client/src/components/team/team-manage/team-infomation-card.jsx
+++ b/client/src/components/team/team-manage/team-infomation-card.jsx
@@ -8,7 +8,7 @@ export default function TeamInformationCard() {
   if (!selectedTeam) return null;
 
   return (
-    <Card className="w-full gap-2 rounded-md shadow-none">
+    <Card className="w-full gap-2 rounded-md">
       <CardHeader>
         <div className="flex flex-row justify-between items-start">
           <div>

--- a/client/src/components/team/team-manage/team-invitation-card.jsx
+++ b/client/src/components/team/team-manage/team-invitation-card.jsx
@@ -6,7 +6,7 @@ export default function TeamInvitationCard() {
   const { selectedTeam } = useTeam();
 
   return (
-    <Card className="w-full gap-2 rounded-md shadow-none">
+    <Card className="w-full gap-2 rounded-md">
       <CardHeader>
         <CardTitle className="w-full font-bold text-2xl line-clamp-2">Invitation Code</CardTitle>
       </CardHeader>

--- a/client/src/components/team/team-manage/team-manage-window.jsx
+++ b/client/src/components/team/team-manage/team-manage-window.jsx
@@ -32,19 +32,19 @@ export default function TeamManageWindow() {
             <TabsList className="justify-start w-full px-6 gap-x-6 rounded-none border-b bg-white">
               <TabsTrigger
                 value="members"
-                className="flex-none p-0 text-sm text-gray-500 rounded-none shadow-none data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:shadow-none"
+                className="flex-none p-0 text-sm text-gray-500 rounded-none data-[state=active]:bg-white data-[state=active]:text-black"
               >
                 Members
               </TabsTrigger>
               <TabsTrigger
                 value="projects"
-                className="flex-none p-0 text-sm text-gray-500 rounded-none shadow-none data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:shadow-none"
+                className="flex-none p-0 text-sm text-gray-500 rounded-none data-[state=active]:bg-white data-[state=active]:text-black"
               >
                 Projects
               </TabsTrigger>
               <TabsTrigger
                 value="invitations"
-                className="flex-none p-0 text-sm text-gray-500 rounded-none shadow-none data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:shadow-none"
+                className="flex-none p-0 text-sm text-gray-500 rounded-none data-[state=active]:bg-white data-[state=active]:text-black"
               >
                 Invitations
               </TabsTrigger>


### PR DESCRIPTION
## Summary
Third of 8 PRs unifying the app's visual style to flat/white/gray-border.

- Removed now-redundant `shadow-none`/`data-[state=active]:shadow-none` from the admin/team-manage/project-manage window tab bars, and from 3 info/invitation Cards — dead weight now that PR1 removed the shadows they were overriding.

## Test plan
- [ ] Manual: Admin, Team, and Project management windows — confirm tabs and info cards still look correct (no visual change expected, this is pure redundant-class cleanup)