### PR TITLE
style(PR4/8): flatten task board, list, and comment composer

### DIFF
--- a/client/src/components/task/comments/comment-input.jsx
+++ b/client/src/components/task/comments/comment-input.jsx
@@ -46,7 +46,7 @@ export default function CommentInput({ task }) {
 
   return (
     <form onSubmit={handleSubmit} className="w-full p-6">
-      <div className="flex flex-col items-end px-1 bg-white border-1 rounded-md shadow-md overflow-hidden">
+      <div className="flex flex-col items-end px-1 bg-white border-1 rounded-md overflow-hidden">
         <Textarea
           ref={textareaRef}
           value={content}

--- a/client/src/components/task/kanban/kanban-item.jsx
+++ b/client/src/components/task/kanban/kanban-item.jsx
@@ -18,7 +18,7 @@ export default function KanbanItem({ task, columnId }) {
 
   return (
     <Card
-      className="p-0 cursor-grab active:cursor-grabbing shadow-xs"
+      className="p-0 cursor-grab active:cursor-grabbing"
       draggable
       onDragStart={handleDragStart}
     >

--- a/client/src/components/task/task-window.jsx
+++ b/client/src/components/task/task-window.jsx
@@ -26,7 +26,7 @@ export default function TaskWindow() {
         <TabsList className="justify-start w-full px-6 gap-x-6 rounded-none border-b bg-white">
           <TabsTrigger
             value="list"
-            className="flex-none p-0 text-sm text-gray-500 rounded-none shadow-none data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:shadow-none"
+            className="flex-none p-0 text-sm text-gray-500 rounded-none data-[state=active]:bg-white data-[state=active]:text-black"
           >
             <div className="flex items-center gap-2">
               <TableProperties className="h-4 w-4" />
@@ -35,7 +35,7 @@ export default function TaskWindow() {
           </TabsTrigger>
           <TabsTrigger
             value="kanban"
-            className="flex-none p-0 text-sm text-gray-500 rounded-none shadow-none data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:shadow-none"
+            className="flex-none p-0 text-sm text-gray-500 rounded-none data-[state=active]:bg-white data-[state=active]:text-black"
           >
             <div className="flex items-center gap-2">
               <AlignStartHorizontal className="h-4 w-4" />


### PR DESCRIPTION
## Summary
Fourth of 8 PRs unifying the app's visual style to flat/white/gray-border.

- Removed explicit `shadow-xs` on Kanban cards and `shadow-md` on the comment composer box.
- Removed redundant `shadow-none` tab overrides in task-window.jsx.

## Test plan
- [ ] Manual: Kanban board cards and the task-comment composer box — confirm flat, still has a visible border