### PR TITLE
style(PR5/8): flatten chat panels

### DIFF
--- a/client/src/components/chat/chat-input.jsx
+++ b/client/src/components/chat/chat-input.jsx
@@ -44,7 +44,7 @@ export default function ChatInput() {
 
   return (
     <form onSubmit={handleSubmit} className="w-full px-4">
-      <div className="flex flex-col items-end px-1 bg-white border-1 rounded-md shadow-md overflow-hidden">
+      <div className="flex flex-col items-end px-1 bg-white border-1 rounded-md overflow-hidden">
         <Textarea
           ref={textareaRef}
           value={message}

--- a/client/src/components/chat/chat-window.jsx
+++ b/client/src/components/chat/chat-window.jsx
@@ -65,7 +65,7 @@ export default function ChatWindow() {
   }
 
   return (
-    <div className="relative flex-1 flex flex-col w-full overflow-hidden bg-ghost-white shadow-md">
+    <div className="relative flex-1 flex flex-col w-full overflow-hidden bg-ghost-white border rounded-none">
       {loading ? (
         <div className="flex-1 flex w-full">
           <Spinner size="lg" className="-translate-y-16" />

--- a/client/src/components/chat/nav-conversation.jsx
+++ b/client/src/components/chat/nav-conversation.jsx
@@ -22,19 +22,19 @@ export default function NavConversation() {
   );
 
   return (
-    <Card className="h-full p-0 shadow-lg rounded-none bg-ghost-white overflow-hidden">
+    <Card className="h-full p-0 rounded-none bg-ghost-white overflow-hidden">
       <CardContent className="p-0 h-full">
         <Tabs defaultValue="all" className="h-full">
           <TabsList className="justify-start w-full px-6 gap-x-6 rounded-none border-b bg-white">
             <TabsTrigger
               value="all"
-              className="flex-none p-0 text-sm text-gray-500 rounded-none shadow-none data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:shadow-none"
+              className="flex-none p-0 text-sm text-gray-500 rounded-none data-[state=active]:bg-white data-[state=active]:text-black"
             >
               All
             </TabsTrigger>
             <TabsTrigger
               value="unread"
-              className="flex-none p-0 text-sm text-gray-500 rounded-none shadow-none data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:shadow-none"
+              className="flex-none p-0 text-sm text-gray-500 rounded-none data-[state=active]:bg-white data-[state=active]:text-black"
             >
               Unread
             </TabsTrigger>


### PR DESCRIPTION
## Summary
Fifth of 8 PRs unifying the app's visual style to flat/white/gray-border.

- Message composer box: removed `shadow-md` (already had a border).
- ChatWindow: removed `shadow-md`, which was its only edge — added a `border` since it had none of its own.
- Conversation list panel: removed `shadow-lg` (Card's own border already provides the edge) and cleaned up redundant `shadow-none` tab overrides.

## Test plan
- [ ] Manual: /app/message — confirm the conversation list and chat panel both look flat with a visible border, no drop shadows