### PR TITLE
style(PR6/8): flatten search dialog, clean up notification tabs

### DIFF
--- a/client/src/components/notification/notification-content.jsx
+++ b/client/src/components/notification/notification-content.jsx
@@ -65,13 +65,13 @@ export default function NotificationContent() {
       <TabsList className="justify-start w-full px-4 gap-x-6 rounded-none border-b bg-white">
         <TabsTrigger
           value="all"
-          className="flex-none p-0 text-sm text-gray-500 rounded-none shadow-none data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:shadow-none"
+          className="flex-none p-0 text-sm text-gray-500 rounded-none data-[state=active]:bg-white data-[state=active]:text-black"
         >
           All
         </TabsTrigger>
         <TabsTrigger
           value="unread"
-          className="flex-none p-0 text-sm text-gray-500 rounded-none shadow-none data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:shadow-none"
+          className="flex-none p-0 text-sm text-gray-500 rounded-none data-[state=active]:bg-white data-[state=active]:text-black"
         >
           {unreadCount > 0 ? `Unread (${unreadCount})` : "Unread"}
         </TabsTrigger>

--- a/client/src/components/search/search-dialog.jsx
+++ b/client/src/components/search/search-dialog.jsx
@@ -14,10 +14,10 @@ export default function SearchDialog() {
   return (
     <DialogContent
       onCloseAutoFocus={(e) => e.preventDefault()}
-      className="flex flex-col gap-y-0 p-0 min-w-1/2 max-w-1/2 min-h-5/6 max-h-5/6 border-none bg-muted overflow-y-scroll"
+      className="flex flex-col gap-y-0 p-0 min-w-1/2 max-w-1/2 min-h-5/6 max-h-5/6 overflow-y-scroll"
     >
       <DialogDescription />
-      <DialogHeader className="py-4 space-y-2 bg-ghost-white shadow-md">
+      <DialogHeader className="py-4 space-y-2 border-b">
         <div className="flex items-center mx-6 px-4 border-1 border-ring rounded-3xl">
           <SearchIcon className="h-5 w-5 text-muted-foreground" />
           {type && (


### PR DESCRIPTION
## Summary
Sixth of 8 PRs unifying the app's visual style to flat/white/gray-border.

- Search dialog: dropped the one-off `bg-muted`/`border-none` override on DialogContent (now matches every other dialog's standard bordered panel) and replaced the header's `shadow-md` with a `border-b` to keep it visually separated from the results list.
- Notification panel: removed redundant `shadow-none` tab overrides.

## Test plan
- [ ] Manual: open global search (⌘K) — confirm the dialog looks like other dialogs (border, no shadow) and the search bar still reads as a distinct header above results