### PR TITLE
style(PR7/8): flatten calendar events and event tooltip

### DIFF
--- a/client/src/components/calendar/calendar-item.jsx
+++ b/client/src/components/calendar/calendar-item.jsx
@@ -27,7 +27,7 @@ export default function CalendarItem({ info }) {
         <TooltipContent
           side="bottom" // Bạn có thể thay đổi position: top, bottom, left, right...
           sideOffset={0} // Khoảng cách giữa trigger và content
-          className="max-w-[200px] bg-ghost-white shadow-lg rounded-lg border"
+          className="max-w-[200px] bg-ghost-white rounded-lg border"
         >
           <div className="space-y-2">
             <div className="text-sm font-semibold text-black">{title}</div>

--- a/client/src/components/calendar/calendar-window.jsx
+++ b/client/src/components/calendar/calendar-window.jsx
@@ -206,7 +206,6 @@ export default function CalendarWindow() {
         .fc-event {
           border-radius: 8px;
           font-size: 0.7rem;
-          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
           margin-bottom: 6px;
           cursor: pointer;
         }


### PR DESCRIPTION
## Summary
Seventh of 8 PRs unifying the app's visual style to flat/white/gray-border.

- Removed the `box-shadow` on FullCalendar event pills (raw CSS, not a Tailwind class, easy to miss in a class-name grep).
- Removed `shadow-lg` on the calendar event hover tooltip (already has a border).

## Test plan
- [ ] Manual: /app/calendar — confirm event pills and their hover tooltip look flat