### PR TITLE
style(PR8/8): flatten auth page form panels

### DIFF
--- a/client/src/app/(auth)/auth/forgot-password/page.jsx
+++ b/client/src/app/(auth)/auth/forgot-password/page.jsx
@@ -21,7 +21,7 @@ export default function ForgotPasswordPage() {
           className="h-full w-full rounded-r-xl object-cover"
         />
       </div>
-      <div className="flex-1 max-w-[500px] p-12 shadow-lg bg-ghost-white flex flex-col justify-center ">
+      <div className="flex-1 max-w-[500px] p-12 border-l bg-ghost-white flex flex-col justify-center ">
         <Suspense fallback={null}>
           <ForgotPasswordForm />
         </Suspense>

--- a/client/src/app/(auth)/auth/login/page.jsx
+++ b/client/src/app/(auth)/auth/login/page.jsx
@@ -21,7 +21,7 @@ export default function LoginPage() {
           className="h-full w-full rounded-r-xl object-cover"
         />
       </div>
-      <div className="flex-1 max-w-[500px] p-12 shadow-lg bg-ghost-white flex flex-col justify-center ">
+      <div className="flex-1 max-w-[500px] p-12 border-l bg-ghost-white flex flex-col justify-center ">
         <Suspense fallback={null}>
           <LoginForm />
         </Suspense>

--- a/client/src/app/(auth)/auth/register/page.jsx
+++ b/client/src/app/(auth)/auth/register/page.jsx
@@ -20,7 +20,7 @@ export default function RegisterPage() {
           className="h-full w-full rounded-r-xl object-cover"
         />
       </div>
-      <div className="flex-1 max-w-[500px] p-12 shadow-lg bg-ghost-white flex flex-col justify-center">
+      <div className="flex-1 max-w-[500px] p-12 border-l bg-ghost-white flex flex-col justify-center">
         <RegisterForm />
       </div>
     </div>

--- a/client/src/app/(auth)/auth/verify/page.jsx
+++ b/client/src/app/(auth)/auth/verify/page.jsx
@@ -20,7 +20,7 @@ export default function VerifyPage() {
           className="h-full w-full rounded-r-xl object-cover"
         />
       </div>
-      <div className="flex-1 max-w-[500px] p-12 shadow-lg bg-ghost-white flex flex-col justify-center ">
+      <div className="flex-1 max-w-[500px] p-12 border-l bg-ghost-white flex flex-col justify-center ">
         <VerifyEmailForm />
       </div>
     </div>


### PR DESCRIPTION
## Summary
Last of 8 PRs unifying the app's visual style to flat/white/gray-border.

- The 4 auth pages (login/register/verify/forgot-password) share a split-screen layout — full-bleed image on one side, form panel on the other — with `shadow-lg` as the only separator between them. Replaced with `border-l`, the natural delimiter for this edge-to-edge layout.

This closes out the full visual-consistency refactor (PR1: shadcn primitives, PR2: dashboard, PR3: team/admin, PR4: task board, PR5: chat, PR6: search/notifications, PR7: calendar, PR8: auth) — every drop shadow in the app's authenticated + auth surfaces has been replaced with a border, and a handful of related dead code / redundant overrides were cleaned up along the way. (Landing/marketing page intentionally left as-is — decorative by design, different surface.)

## Test plan
- [ ] Manual: /auth/login, /auth/register, /auth/verify, /auth/forgot-password — confirm the form panel has a clean left border instead of a shadow