### PR TITLE
style: pull back over-applied borders, pure white page background

### DIFF
--- a/client/src/app/(auth)/auth/forgot-password/page.jsx
+++ b/client/src/app/(auth)/auth/forgot-password/page.jsx
@@ -21,7 +21,7 @@ export default function ForgotPasswordPage() {
           className="h-full w-full rounded-r-xl object-cover"
         />
       </div>
-      <div className="flex-1 max-w-[500px] p-12 border-l bg-ghost-white flex flex-col justify-center ">
+      <div className="flex-1 max-w-[500px] p-12 bg-ghost-white flex flex-col justify-center ">
         <Suspense fallback={null}>
           <ForgotPasswordForm />
         </Suspense>

--- a/client/src/app/(auth)/auth/login/page.jsx
+++ b/client/src/app/(auth)/auth/login/page.jsx
@@ -21,7 +21,7 @@ export default function LoginPage() {
           className="h-full w-full rounded-r-xl object-cover"
         />
       </div>
-      <div className="flex-1 max-w-[500px] p-12 border-l bg-ghost-white flex flex-col justify-center ">
+      <div className="flex-1 max-w-[500px] p-12 bg-ghost-white flex flex-col justify-center ">
         <Suspense fallback={null}>
           <LoginForm />
         </Suspense>

--- a/client/src/app/(auth)/auth/register/page.jsx
+++ b/client/src/app/(auth)/auth/register/page.jsx
@@ -20,7 +20,7 @@ export default function RegisterPage() {
           className="h-full w-full rounded-r-xl object-cover"
         />
       </div>
-      <div className="flex-1 max-w-[500px] p-12 border-l bg-ghost-white flex flex-col justify-center">
+      <div className="flex-1 max-w-[500px] p-12 bg-ghost-white flex flex-col justify-center">
         <RegisterForm />
       </div>
     </div>

--- a/client/src/app/(auth)/auth/verify/page.jsx
+++ b/client/src/app/(auth)/auth/verify/page.jsx
@@ -20,7 +20,7 @@ export default function VerifyPage() {
           className="h-full w-full rounded-r-xl object-cover"
         />
       </div>
-      <div className="flex-1 max-w-[500px] p-12 border-l bg-ghost-white flex flex-col justify-center ">
+      <div className="flex-1 max-w-[500px] p-12 bg-ghost-white flex flex-col justify-center ">
         <VerifyEmailForm />
       </div>
     </div>

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -107,7 +107,7 @@
 
 :root {
   --radius: 0.625rem;
-  --background: var(--color-ghost-white);
+  --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);

--- a/client/src/components/chat/chat-window.jsx
+++ b/client/src/components/chat/chat-window.jsx
@@ -65,7 +65,7 @@ export default function ChatWindow() {
   }
 
   return (
-    <div className="relative flex-1 flex flex-col w-full overflow-hidden bg-ghost-white border rounded-none">
+    <div className="relative flex-1 flex flex-col w-full overflow-hidden bg-ghost-white">
       {loading ? (
         <div className="flex-1 flex w-full">
           <Spinner size="lg" className="-translate-y-16" />

--- a/client/src/components/ui/sidebar.jsx
+++ b/client/src/components/ui/sidebar.jsx
@@ -275,7 +275,7 @@ function SidebarInset({ className, ...props }) {
       data-slot="sidebar-inset"
       className={cn(
         "bg-background relative flex w-full flex-1 flex-col",
-        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:border md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
Follow-up correction after feedback that the shadow-removal refactor over-applied borders to generic containers.

- Removed border from `SidebarInset` (the whole header+content pane), `ChatWindow`, and the auth pages' split-screen form panel — none of these are cards or genuine dividers, so they should be fully flat with no edge treatment.
- Changed `--background` from ghost-white to pure white — the page canvas still read as slightly off-white.

Border is now reserved for actual Card/Dialog-style surfaces and genuine section dividers (e.g. a tab bar's `border-b`).

## Test plan
- [ ] Manual: Dashboard/Task/Team pages — confirm the header+content pane has no border around it, page background reads as true white
- [ ] Manual: /app/message — confirm ChatWindow has no border
- [ ] Manual: auth pages — confirm the form panel has no left border