### PR TITLE
style(admin): brighten health status banner gradient

### DIFF
--- a/client/src/components/admin/admin-health-panel.jsx
+++ b/client/src/components/admin/admin-health-panel.jsx
@@ -64,7 +64,9 @@ export default function AdminHealthPanel() {
         <div
           className={cn(
             "flex items-center justify-between gap-4 rounded-xl p-6 text-white",
-            allHealthy ? "bg-prussian-blue" : "bg-gradient-to-br from-prussian-blue to-red-900"
+            allHealthy
+              ? "bg-prussian-blue"
+              : "bg-gradient-to-r from-blue-green from-0% via-blue-green via-65% to-red-900 to-100%"
           )}
         >
           <div>


### PR DESCRIPTION
## Summary
- Health tab status banner used a diagonal gradient (`prussian-blue` → `red-900`) that, on a wide/short banner, squeezed the blue into the top-left corner so red dominated visually.
- Switched to a horizontal gradient using the app's existing `blue-green` accent, extended to ~65% of the width before transitioning to red, so blue reads as the dominant color again.

## Test plan
- [x] `yarn build` passes
- [ ] Visually verify the Health tab banner in the unhealthy state