### PR TITLE
feat(chat): add real-time typing indicator

### DIFF
--- a/client/src/components/chat/chat-header.jsx
+++ b/client/src/components/chat/chat-header.jsx
@@ -8,17 +8,48 @@ import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useChat } from "@/hooks/use-chat";
 import { useSocket } from "@/hooks/use-socket";
+import { useSession } from "@/hooks/use-session";
 import { getInitials, pickAvatarColor } from "@/lib/user-utils";
 import { cn, capitalCase } from "@/lib/utils";
 
+// Group chats don't carry a participants list, so names for anyone other
+// than the current typist are best-effort, resolved from senders seen in
+// the already-loaded message history.
+function useTypingText(currConversation, typingUserIds, messages, currentUserId) {
+  return useMemo(() => {
+    if (!currConversation) return null;
+
+    const typistIds = typingUserIds.filter((id) => id !== currentUserId);
+    if (!typistIds.length) return null;
+
+    if (currConversation.type === "direct") {
+      return typistIds.includes(currConversation.direct_user_id)
+        ? `${currConversation.title} is typing...`
+        : null;
+    }
+
+    const nameById = new Map();
+    messages.forEach((msg) => nameById.set(msg.sender_id, msg.sender_full_name));
+
+    const names = typistIds.map((id) => nameById.get(id) || "Someone");
+
+    if (names.length === 1) return `${names[0]} is typing...`;
+    if (names.length === 2) return `${names[0]} and ${names[1]} are typing...`;
+    return `${names[0]} and ${names.length - 1} others are typing...`;
+  }, [currConversation, typingUserIds, messages, currentUserId]);
+}
+
 export default function ChatHeader() {
-  const { conversations, selectedConversationId } = useChat();
+  const { conversations, selectedConversationId, typingUserIds, messages } = useChat();
   const { onlineUserIds } = useSocket();
+  const { user } = useSession();
 
   const currConversation = useMemo(
     () => conversations.find((c) => c.id === selectedConversationId),
     [conversations, selectedConversationId]
   );
+
+  const typingText = useTypingText(currConversation, typingUserIds, messages, user?.id);
 
   if (!currConversation) {
     return;
@@ -56,33 +87,37 @@ export default function ChatHeader() {
               ? "Team Chat"
               : "Project Chat")}
         </div>
-        <div className="flex items-center gap-2">
-          {currConversation.type !== "direct" && (
-            <Badge
-              className={cn(
-                "flex-none text-[10px] rounded-sm h-4",
-                currConversation.type === "team" ? "bg-red-400" : "bg-blue-400"
-              )}
-            >
-              {capitalCase(currConversation.type)}
-            </Badge>
-          )}
-          {currConversation.type !== "direct" && (
-            <TooltipProvider>
-              <Tooltip delayDuration={500}>
-                <TooltipTrigger asChild>
-                  <div className="flex items-center px-2 py-1 gap-1 text-xs text-gray-500 rounded-sm hover:bg-prussian-blue/10 hover:cursor-pointer transition duration-200 ease-in-out">
-                    <UsersRound className="h-3 w-3" />
-                    <span>{currConversation.participant_count}</span>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" className="bg-prussian-blue text-white">
-                  <p>{`${currConversation.participant_count} members`}</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          )}
-        </div>
+        {typingText ? (
+          <p className="text-xs text-blue-green italic animate-pulse truncate">{typingText}</p>
+        ) : (
+          <div className="flex items-center gap-2">
+            {currConversation.type !== "direct" && (
+              <Badge
+                className={cn(
+                  "flex-none text-[10px] rounded-sm h-4",
+                  currConversation.type === "team" ? "bg-red-400" : "bg-blue-400"
+                )}
+              >
+                {capitalCase(currConversation.type)}
+              </Badge>
+            )}
+            {currConversation.type !== "direct" && (
+              <TooltipProvider>
+                <Tooltip delayDuration={500}>
+                  <TooltipTrigger asChild>
+                    <div className="flex items-center px-2 py-1 gap-1 text-xs text-gray-500 rounded-sm hover:bg-prussian-blue/10 hover:cursor-pointer transition duration-200 ease-in-out">
+                      <UsersRound className="h-3 w-3" />
+                      <span>{currConversation.participant_count}</span>
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="bg-prussian-blue text-white">
+                    <p>{`${currConversation.participant_count} members`}</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/client/src/components/chat/chat-input.jsx
+++ b/client/src/components/chat/chat-input.jsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
+import { useDebouncedCallback } from "use-debounce";
 import { Send, Paperclip } from "lucide-react";
 
 import { Textarea } from "@/components/ui/textarea";
@@ -10,7 +11,23 @@ import { useChat } from "@/hooks/use-chat";
 export default function ChatInput() {
   const [message, setMessage] = useState("");
   const textareaRef = useRef(null);
-  const { sendMessage } = useChat();
+  const { sendMessage, sendTyping, stopTyping } = useChat();
+
+  // Re-announce "typing" at most once every 2s while the user keeps typing
+  // (leading-edge only), and announce "stopped typing" 2s after they pause.
+  const throttledSendTyping = useDebouncedCallback(sendTyping, 2000, {
+    leading: true,
+    trailing: false
+  });
+  const debouncedStopTyping = useDebouncedCallback(stopTyping, 2000);
+
+  useEffect(() => {
+    return () => {
+      throttledSendTyping.cancel();
+      debouncedStopTyping.cancel();
+      stopTyping();
+    };
+  }, []);
 
   const handleChange = (e) => {
     setMessage(e.target.value);
@@ -18,11 +35,23 @@ export default function ChatInput() {
       textareaRef.current.style.height = "auto";
       textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
     }
+
+    if (e.target.value.trim()) {
+      throttledSendTyping();
+      debouncedStopTyping();
+    } else {
+      throttledSendTyping.cancel();
+      debouncedStopTyping.cancel();
+      stopTyping();
+    }
   };
 
   const submitMessage = () => {
     const text = message.trim();
     if (!text) return;
+    throttledSendTyping.cancel();
+    debouncedStopTyping.cancel();
+    stopTyping();
     sendMessage(text);
     setMessage("");
     if (textareaRef.current) {

--- a/client/src/hooks/use-chat.js
+++ b/client/src/hooks/use-chat.js
@@ -27,8 +27,10 @@ export function ChatProvider({ children }) {
   const [scrollTargetId, setScrollTargetId] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [typingUserIds, setTypingUserIds] = useState([]);
 
   const selectedIdRef = useRef(selectedConversationId);
+  const typingTimeoutsRef = useRef({});
   // Tracks which not-yet-cached conversation id we've already retried a fetch
   // for, so the URL-matching effect below retries once instead of looping.
   const attemptedFetchIdRef = useRef(null);
@@ -103,10 +105,39 @@ export function ChatProvider({ children }) {
       }
     };
 
+    // Guards against a "stop_typing" emit getting lost (dropped connection,
+    // tab closed mid-typing) leaving a stale "is typing..." indicator forever.
+    const clearTypingTimeout = (userId) => {
+      clearTimeout(typingTimeoutsRef.current[userId]);
+      delete typingTimeoutsRef.current[userId];
+    };
+
+    const handleUserTyping = ({ conversation_id, user_id }) => {
+      if (conversation_id !== selectedConversationId) return;
+
+      setTypingUserIds((prev) => (prev.includes(user_id) ? prev : [...prev, user_id]));
+
+      clearTypingTimeout(user_id);
+      typingTimeoutsRef.current[user_id] = setTimeout(() => {
+        delete typingTimeoutsRef.current[user_id];
+        setTypingUserIds((prev) => prev.filter((id) => id !== user_id));
+      }, 4000);
+    };
+
+    const handleUserStoppedTyping = ({ conversation_id, user_id }) => {
+      if (conversation_id !== selectedConversationId) return;
+
+      clearTypingTimeout(user_id);
+      setTypingUserIds((prev) => prev.filter((id) => id !== user_id));
+    };
+
     socket.on("update_conversation", handleUpdateConv);
     socket.on("new_message", handleNewMsg);
+    socket.on("user_typing", handleUserTyping);
+    socket.on("user_stopped_typing", handleUserStoppedTyping);
 
     setLoading(true);
+    setTypingUserIds([]);
 
     getMessagesOfConversation(selectedConversationId)
       .then((data) => {
@@ -118,6 +149,11 @@ export function ChatProvider({ children }) {
     return () => {
       socket.off("update_conversation", handleUpdateConv);
       socket.off("new_message", handleNewMsg);
+      socket.off("user_typing", handleUserTyping);
+      socket.off("user_stopped_typing", handleUserStoppedTyping);
+
+      Object.values(typingTimeoutsRef.current).forEach(clearTimeout);
+      typingTimeoutsRef.current = {};
     };
   }, [socket, socketConnected, sessionLoading, selectedConversationId]);
 
@@ -147,6 +183,18 @@ export function ChatProvider({ children }) {
     [socket, socketConnected]
   );
 
+  const sendTyping = useCallback(() => {
+    const cid = selectedIdRef.current;
+    if (!socketConnected || !cid) return;
+    socket.emit("typing", { conversation_id: cid });
+  }, [socket, socketConnected]);
+
+  const stopTyping = useCallback(() => {
+    const cid = selectedIdRef.current;
+    if (!socketConnected || !cid) return;
+    socket.emit("stop_typing", { conversation_id: cid });
+  }, [socket, socketConnected]);
+
   return (
     <ChatContext.Provider
       value={{
@@ -156,6 +204,9 @@ export function ChatProvider({ children }) {
         messages,
         lastReadMessageId,
         sendMessage,
+        typingUserIds,
+        sendTyping,
+        stopTyping,
         highlightId,
         setHighlightId,
         scrollTargetId,

--- a/server/src/socket/index.js
+++ b/server/src/socket/index.js
@@ -5,6 +5,7 @@ import userModel from "../api/models/user-model.js";
 import registerConversationHandlers from "./conversation-socket.js";
 import registerMessageHandlers from "./message-socket.js";
 import registerTaskCommentHandlers from "./task-comment-socket.js";
+import registerTypingHandlers from "./typing-socket.js";
 
 let ioInstance = null;
 
@@ -75,9 +76,17 @@ const setupSocket = (server) => {
     registerConversationHandlers(io, socket);
     registerMessageHandlers(io, socket);
     registerTaskCommentHandlers(io, socket);
+    registerTypingHandlers(io, socket);
 
     socket.on("disconnect", () => {
       if (!userId) return;
+
+      const currentConversationId = socket.data.conversation_id;
+      if (currentConversationId) {
+        socket
+          .to(`conversation_${currentConversationId}`)
+          .emit("user_stopped_typing", { conversation_id: currentConversationId, user_id: userId });
+      }
 
       const sockets = connectionsByUser.get(userId);
       if (!sockets) return;

--- a/server/src/socket/typing-socket.js
+++ b/server/src/socket/typing-socket.js
@@ -1,0 +1,17 @@
+const registerTypingHandlers = (io, socket) => {
+  socket.on("typing", ({ conversation_id }) => {
+    const { id: user_id } = socket.data.user;
+
+    socket.to(`conversation_${conversation_id}`).emit("user_typing", { conversation_id, user_id });
+  });
+
+  socket.on("stop_typing", ({ conversation_id }) => {
+    const { id: user_id } = socket.data.user;
+
+    socket
+      .to(`conversation_${conversation_id}`)
+      .emit("user_stopped_typing", { conversation_id, user_id });
+  });
+};
+
+export default registerTypingHandlers;


### PR DESCRIPTION
## Summary
- Server: new `typing`/`stop_typing` socket events relayed to the existing `conversation_${id}` room (same pattern as `send_message`); also clears typing state on disconnect.
- Client (`use-chat.js`): tracks `typingUserIds` for the open conversation, with a 4s auto-expiry safety net in case a `stop_typing` emit is lost.
- Client (`chat-input.jsx`): emits `typing` (throttled, leading-edge every 2s) while the user types, and `stop_typing` after a 2s pause or on send/unmount.
- Client (`chat-header.jsx`): shows "X is typing..." — resolves the name from the conversation title for direct chats, or from senders already seen in loaded message history for group chats (falls back to "Someone" for a member who hasn't posted yet).

## Test plan
- [x] `yarn build` passes
- [x] `node --check` on all server files passes
- [ ] Manually verify in two browser sessions: typing shows/hides correctly in both direct and group conversations