### PR TITLE
feat(chat): typing indicator in conversation list + Messenger-style bubble

### DIFF
--- a/client/src/components/chat/chat-header.jsx
+++ b/client/src/components/chat/chat-header.jsx
@@ -8,48 +8,17 @@ import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useChat } from "@/hooks/use-chat";
 import { useSocket } from "@/hooks/use-socket";
-import { useSession } from "@/hooks/use-session";
 import { getInitials, pickAvatarColor } from "@/lib/user-utils";
 import { cn, capitalCase } from "@/lib/utils";
 
-// Group chats don't carry a participants list, so names for anyone other
-// than the current typist are best-effort, resolved from senders seen in
-// the already-loaded message history.
-function useTypingText(currConversation, typingUserIds, messages, currentUserId) {
-  return useMemo(() => {
-    if (!currConversation) return null;
-
-    const typistIds = typingUserIds.filter((id) => id !== currentUserId);
-    if (!typistIds.length) return null;
-
-    if (currConversation.type === "direct") {
-      return typistIds.includes(currConversation.direct_user_id)
-        ? `${currConversation.title} is typing...`
-        : null;
-    }
-
-    const nameById = new Map();
-    messages.forEach((msg) => nameById.set(msg.sender_id, msg.sender_full_name));
-
-    const names = typistIds.map((id) => nameById.get(id) || "Someone");
-
-    if (names.length === 1) return `${names[0]} is typing...`;
-    if (names.length === 2) return `${names[0]} and ${names[1]} are typing...`;
-    return `${names[0]} and ${names.length - 1} others are typing...`;
-  }, [currConversation, typingUserIds, messages, currentUserId]);
-}
-
 export default function ChatHeader() {
-  const { conversations, selectedConversationId, typingUserIds, messages } = useChat();
+  const { conversations, selectedConversationId } = useChat();
   const { onlineUserIds } = useSocket();
-  const { user } = useSession();
 
   const currConversation = useMemo(
     () => conversations.find((c) => c.id === selectedConversationId),
     [conversations, selectedConversationId]
   );
-
-  const typingText = useTypingText(currConversation, typingUserIds, messages, user?.id);
 
   if (!currConversation) {
     return;
@@ -87,37 +56,33 @@ export default function ChatHeader() {
               ? "Team Chat"
               : "Project Chat")}
         </div>
-        {typingText ? (
-          <p className="text-xs text-blue-green italic animate-pulse truncate">{typingText}</p>
-        ) : (
-          <div className="flex items-center gap-2">
-            {currConversation.type !== "direct" && (
-              <Badge
-                className={cn(
-                  "flex-none text-[10px] rounded-sm h-4",
-                  currConversation.type === "team" ? "bg-red-400" : "bg-blue-400"
-                )}
-              >
-                {capitalCase(currConversation.type)}
-              </Badge>
-            )}
-            {currConversation.type !== "direct" && (
-              <TooltipProvider>
-                <Tooltip delayDuration={500}>
-                  <TooltipTrigger asChild>
-                    <div className="flex items-center px-2 py-1 gap-1 text-xs text-gray-500 rounded-sm hover:bg-prussian-blue/10 hover:cursor-pointer transition duration-200 ease-in-out">
-                      <UsersRound className="h-3 w-3" />
-                      <span>{currConversation.participant_count}</span>
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" className="bg-prussian-blue text-white">
-                    <p>{`${currConversation.participant_count} members`}</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
-          </div>
-        )}
+        <div className="flex items-center gap-2">
+          {currConversation.type !== "direct" && (
+            <Badge
+              className={cn(
+                "flex-none text-[10px] rounded-sm h-4",
+                currConversation.type === "team" ? "bg-red-400" : "bg-blue-400"
+              )}
+            >
+              {capitalCase(currConversation.type)}
+            </Badge>
+          )}
+          {currConversation.type !== "direct" && (
+            <TooltipProvider>
+              <Tooltip delayDuration={500}>
+                <TooltipTrigger asChild>
+                  <div className="flex items-center px-2 py-1 gap-1 text-xs text-gray-500 rounded-sm hover:bg-prussian-blue/10 hover:cursor-pointer transition duration-200 ease-in-out">
+                    <UsersRound className="h-3 w-3" />
+                    <span>{currConversation.participant_count}</span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="bg-prussian-blue text-white">
+                  <p>{`${currConversation.participant_count} members`}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/chat/chat-window.jsx
+++ b/client/src/components/chat/chat-window.jsx
@@ -5,12 +5,13 @@ import { MoveDown } from "lucide-react";
 
 import ChatInput from "@/components/chat/chat-input";
 import MessageBubble from "@/components/chat/message-bubble";
+import TypingBubble from "@/components/chat/typing-bubble";
 import Spinner from "@/components/app/spinner";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
 import { useChat } from "@/hooks/use-chat";
 import { useSession } from "@/hooks/use-session";
-import { groupMessages } from "@/lib/chat-utils";
+import { groupMessages, getTypingParticipants } from "@/lib/chat-utils";
 
 const SCROLL_THRESHOLD = 300;
 
@@ -20,6 +21,7 @@ export default function ChatWindow() {
     messages,
     conversations,
     selectedConversationId,
+    typingUserIds,
     loading,
     scrollTargetId,
     setScrollTargetId,
@@ -35,17 +37,24 @@ export default function ChatWindow() {
     [conversations, selectedConversationId]
   );
 
+  const typists = useMemo(
+    () => getTypingParticipants(currConversation, typingUserIds, messages, user?.id),
+    [currConversation, typingUserIds, messages, user?.id]
+  );
+
   const handleScroll = (e) => {
     const { scrollTop, scrollHeight, clientHeight } = e.target;
     setShowScrollToBottom(scrollHeight - scrollTop - clientHeight > SCROLL_THRESHOLD);
   };
 
-  // Always scroll to bottom on new messages (unless hidden by user scroll)
+  // Always scroll to bottom on new messages (unless hidden by user scroll).
+  // Also re-run when the typing bubble appears/disappears so it isn't left
+  // just out of view below the fold.
   useEffect(() => {
     if (!showScrollToBottom && bottomRef.current) {
       bottomRef.current.scrollIntoView({ behavior: "instant" });
     }
-  }, [messages]);
+  }, [messages, typists.length]);
 
   useEffect(() => {
     if (!loading && scrollTargetId && scrollAreaRef.current) {
@@ -79,6 +88,7 @@ export default function ChatWindow() {
           {groupMessages(messages)?.map((msgGroup, idx) => (
             <MessageBubble key={idx} msgGroup={msgGroup} isMe={msgGroup.sender_id === user?.id} />
           ))}
+          <TypingBubble typists={typists} />
           <div ref={bottomRef} />
         </ScrollArea>
       )}

--- a/client/src/components/chat/nav-conversation-item.jsx
+++ b/client/src/components/chat/nav-conversation-item.jsx
@@ -4,13 +4,20 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { useChat } from "@/hooks/use-chat";
 import { useSocket } from "@/hooks/use-socket";
+import { useSession } from "@/hooks/use-session";
 import { getInitials, pickAvatarColor } from "@/lib/user-utils";
 import { cn, capitalCase, formatShortTimestamp } from "@/lib/utils";
 
 export default function NavConversationItem({ conversation }) {
   const { selectedConversationId, changeConversation } = useChat();
-  const { onlineUserIds } = useSocket();
+  const { onlineUserIds, typingByConversation } = useSocket();
+  const { user } = useSession();
   const selected = conversation.id === selectedConversationId;
+
+  // No message history is loaded for conversations other than the open one,
+  // so group-chat typists can't be resolved to a name here (unlike the chat
+  // header) — only direct conversations can, via their already-known title.
+  const isTyping = (typingByConversation[conversation.id] ?? []).some((id) => id !== user?.id);
 
   return (
     <li
@@ -75,14 +82,20 @@ export default function NavConversationItem({ conversation }) {
             </Badge>
           )}
         </div>
-        <p
-          className={cn(
-            "text-left text-xs text-gray-500 truncate",
-            conversation.unread_count > 0 && "font-bold"
-          )}
-        >
-          {conversation.latest_message_content || "No messages yet"}
-        </p>
+        {isTyping ? (
+          <p className="text-left text-xs text-blue-green italic animate-pulse truncate">
+            {conversation.type === "direct" ? `${conversation.title} is typing...` : "Someone is typing..."}
+          </p>
+        ) : (
+          <p
+            className={cn(
+              "text-left text-xs text-gray-500 truncate",
+              conversation.unread_count > 0 && "font-bold"
+            )}
+          >
+            {conversation.latest_message_content || "No messages yet"}
+          </p>
+        )}
       </div>
 
       {/* Column 3: Timestamp */}

--- a/client/src/components/chat/typing-bubble.jsx
+++ b/client/src/components/chat/typing-bubble.jsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { AnimatePresence, motion } from "motion/react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { getInitials, pickAvatarColor } from "@/lib/user-utils";
+
+function TypingDots() {
+  return (
+    <span className="flex items-center gap-1">
+      {[0, 1, 2].map((i) => (
+        <motion.span
+          key={i}
+          className="h-1.5 w-1.5 rounded-full bg-gray-500"
+          animate={{ y: ["0%", "-40%", "0%"] }}
+          transition={{ duration: 0.9, repeat: Infinity, delay: i * 0.15, ease: "easeInOut" }}
+        />
+      ))}
+    </span>
+  );
+}
+
+export default function TypingBubble({ typists }) {
+  const typing = typists[0];
+
+  return (
+    <AnimatePresence>
+      {typing && (
+        <motion.div
+          key={typing.id}
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 12 }}
+          transition={{ duration: 0.25, ease: "easeOut" }}
+          className="flex justify-start items-end gap-x-3 mt-4"
+        >
+          <Avatar className="h-8 w-8 flex-none">
+            <AvatarImage src={typing.avatar_url} alt={typing.full_name} className="object-cover" />
+            <AvatarFallback className="text-sm" style={pickAvatarColor(typing.full_name)}>
+              {getInitials(typing.full_name)}
+            </AvatarFallback>
+          </Avatar>
+          <div className="flex items-center px-4 py-3 rounded-2xl rounded-bl-none bg-gray-200">
+            <TypingDots />
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/client/src/hooks/use-chat.js
+++ b/client/src/hooks/use-chat.js
@@ -15,7 +15,7 @@ export function useChat() {
 
 export function ChatProvider({ children }) {
   const { loading: sessionLoading } = useSession();
-  const { socket, connected: socketConnected } = useSocket();
+  const { socket, connected: socketConnected, typingByConversation } = useSocket();
   const router = useRouter();
   const pathname = usePathname();
 
@@ -27,10 +27,10 @@ export function ChatProvider({ children }) {
   const [scrollTargetId, setScrollTargetId] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [typingUserIds, setTypingUserIds] = useState([]);
+
+  const typingUserIds = typingByConversation[selectedConversationId] ?? [];
 
   const selectedIdRef = useRef(selectedConversationId);
-  const typingTimeoutsRef = useRef({});
   // Tracks which not-yet-cached conversation id we've already retried a fetch
   // for, so the URL-matching effect below retries once instead of looping.
   const attemptedFetchIdRef = useRef(null);
@@ -105,39 +105,10 @@ export function ChatProvider({ children }) {
       }
     };
 
-    // Guards against a "stop_typing" emit getting lost (dropped connection,
-    // tab closed mid-typing) leaving a stale "is typing..." indicator forever.
-    const clearTypingTimeout = (userId) => {
-      clearTimeout(typingTimeoutsRef.current[userId]);
-      delete typingTimeoutsRef.current[userId];
-    };
-
-    const handleUserTyping = ({ conversation_id, user_id }) => {
-      if (conversation_id !== selectedConversationId) return;
-
-      setTypingUserIds((prev) => (prev.includes(user_id) ? prev : [...prev, user_id]));
-
-      clearTypingTimeout(user_id);
-      typingTimeoutsRef.current[user_id] = setTimeout(() => {
-        delete typingTimeoutsRef.current[user_id];
-        setTypingUserIds((prev) => prev.filter((id) => id !== user_id));
-      }, 4000);
-    };
-
-    const handleUserStoppedTyping = ({ conversation_id, user_id }) => {
-      if (conversation_id !== selectedConversationId) return;
-
-      clearTypingTimeout(user_id);
-      setTypingUserIds((prev) => prev.filter((id) => id !== user_id));
-    };
-
     socket.on("update_conversation", handleUpdateConv);
     socket.on("new_message", handleNewMsg);
-    socket.on("user_typing", handleUserTyping);
-    socket.on("user_stopped_typing", handleUserStoppedTyping);
 
     setLoading(true);
-    setTypingUserIds([]);
 
     getMessagesOfConversation(selectedConversationId)
       .then((data) => {
@@ -149,11 +120,6 @@ export function ChatProvider({ children }) {
     return () => {
       socket.off("update_conversation", handleUpdateConv);
       socket.off("new_message", handleNewMsg);
-      socket.off("user_typing", handleUserTyping);
-      socket.off("user_stopped_typing", handleUserStoppedTyping);
-
-      Object.values(typingTimeoutsRef.current).forEach(clearTimeout);
-      typingTimeoutsRef.current = {};
     };
   }, [socket, socketConnected, sessionLoading, selectedConversationId]);
 

--- a/client/src/hooks/use-socket.js
+++ b/client/src/hooks/use-socket.js
@@ -16,6 +16,14 @@ export function SocketProvider({ children }) {
   const socketRef = useRef(null);
   const [connected, setConnected] = useState(false);
   const [onlineUserIds, setOnlineUserIds] = useState(new Set());
+  // conversationId -> array of user ids currently typing there. Kept here
+  // (rather than in useChat) so it covers every conversation the user is a
+  // member of, not just whichever one is currently open — the server relays
+  // "typing" to each participant's personal room regardless of what they
+  // have open, so this map can power both the open chat header and the
+  // conversation list.
+  const [typingByConversation, setTypingByConversation] = useState({});
+  const typingTimeoutsRef = useRef({});
 
   useEffect(() => {
     // Only connect when session is loaded and user is present
@@ -55,6 +63,44 @@ export function SocketProvider({ children }) {
         });
       });
 
+      const clearTypingTimeout = (key) => {
+        clearTimeout(typingTimeoutsRef.current[key]);
+        delete typingTimeoutsRef.current[key];
+      };
+
+      const removeTypingUser = (conversation_id, user_id) => {
+        clearTypingTimeout(`${conversation_id}:${user_id}`);
+        setTypingByConversation((prev) => {
+          const existing = prev[conversation_id];
+          if (!existing?.length) return prev;
+          return { ...prev, [conversation_id]: existing.filter((id) => id !== user_id) };
+        });
+      };
+
+      // Safety net: auto-clear after 4s in case a "stop_typing" emit is
+      // lost (dropped connection, tab closed mid-typing).
+      const addTypingUser = (conversation_id, user_id) => {
+        setTypingByConversation((prev) => {
+          const existing = prev[conversation_id] ?? [];
+          if (existing.includes(user_id)) return prev;
+          return { ...prev, [conversation_id]: [...existing, user_id] };
+        });
+
+        const key = `${conversation_id}:${user_id}`;
+        clearTypingTimeout(key);
+        typingTimeoutsRef.current[key] = setTimeout(() => {
+          delete typingTimeoutsRef.current[key];
+          removeTypingUser(conversation_id, user_id);
+        }, 4000);
+      };
+
+      socketRef.current.on("user_typing", ({ conversation_id, user_id }) =>
+        addTypingUser(conversation_id, user_id)
+      );
+      socketRef.current.on("user_stopped_typing", ({ conversation_id, user_id }) =>
+        removeTypingUser(conversation_id, user_id)
+      );
+
       // Emit setup event with userId to authenticate socket
       socketRef.current.emit("setup");
       setConnected(true);
@@ -68,11 +114,17 @@ export function SocketProvider({ children }) {
         setConnected(false);
         setOnlineUserIds(new Set());
       }
+
+      Object.values(typingTimeoutsRef.current).forEach(clearTimeout);
+      typingTimeoutsRef.current = {};
+      setTypingByConversation({});
     };
   }, [loading, user]); // rerun when loading or user changes
 
   return (
-    <SocketContext.Provider value={{ socket: socketRef.current, connected, onlineUserIds }}>
+    <SocketContext.Provider
+      value={{ socket: socketRef.current, connected, onlineUserIds, typingByConversation }}
+    >
       {children}
     </SocketContext.Provider>
   );

--- a/client/src/lib/chat-utils.js
+++ b/client/src/lib/chat-utils.js
@@ -32,6 +32,41 @@ export function groupMessages(messages) {
   return groupedMessages;
 }
 
+// Resolves typing user ids to a displayable {id, full_name, avatar_url} —
+// direct conversations always resolve via the conversation itself (the
+// title/avatar_url already ARE the other participant's), group conversations
+// only resolve for senders already seen in the loaded message history, since
+// no participants list is fetched for the chat view.
+export function getTypingParticipants(conversation, typingUserIds, messages, currentUserId) {
+  if (!conversation) return [];
+
+  const typistIds = typingUserIds.filter((id) => id !== currentUserId);
+  if (!typistIds.length) return [];
+
+  if (conversation.type === "direct") {
+    return typistIds.includes(conversation.direct_user_id)
+      ? [
+          {
+            id: conversation.direct_user_id,
+            full_name: conversation.title,
+            avatar_url: conversation.avatar_url
+          }
+        ]
+      : [];
+  }
+
+  const byId = new Map();
+  messages.forEach((msg) =>
+    byId.set(msg.sender_id, { full_name: msg.sender_full_name, avatar_url: msg.sender_avatar_url })
+  );
+
+  return typistIds.map((id) => ({
+    id,
+    full_name: byId.get(id)?.full_name ?? "Someone",
+    avatar_url: byId.get(id)?.avatar_url ?? null
+  }));
+}
+
 export function linkifyMessage(message) {
   const urlRegex = /(https?:\/\/[\w.-]+(?:\/[\w\-._~:\/?#[\]@!$&'()*+,;=]*)?)/g;
   return message.split(urlRegex).map((part, idx) => {

--- a/server/src/socket/index.js
+++ b/server/src/socket/index.js
@@ -2,6 +2,7 @@ import { Server } from "socket.io";
 
 import authMiddleware from "../middlewares/auth-middleware.js";
 import userModel from "../api/models/user-model.js";
+import conversationService from "../api/services/conversation-service.js";
 import registerConversationHandlers from "./conversation-socket.js";
 import registerMessageHandlers from "./message-socket.js";
 import registerTaskCommentHandlers from "./task-comment-socket.js";
@@ -83,9 +84,17 @@ const setupSocket = (server) => {
 
       const currentConversationId = socket.data.conversation_id;
       if (currentConversationId) {
-        socket
-          .to(`conversation_${currentConversationId}`)
-          .emit("user_stopped_typing", { conversation_id: currentConversationId, user_id: userId });
+        conversationService
+          .getParticipantsOfConversation(currentConversationId, userId)
+          .then((participants) => {
+            participants.forEach((p) => {
+              io.to(`user_${p.id}`).emit("user_stopped_typing", {
+                conversation_id: currentConversationId,
+                user_id: userId
+              });
+            });
+          })
+          .catch(() => {});
       }
 
       const sockets = connectionsByUser.get(userId);

--- a/server/src/socket/typing-socket.js
+++ b/server/src/socket/typing-socket.js
@@ -1,16 +1,41 @@
-const registerTypingHandlers = (io, socket) => {
-  socket.on("typing", ({ conversation_id }) => {
-    const { id: user_id } = socket.data.user;
+import conversationService from "../api/services/conversation-service.js";
 
-    socket.to(`conversation_${conversation_id}`).emit("user_typing", { conversation_id, user_id });
+// Broadcast to each participant's personal room (not the conversation room)
+// so typing status reaches every device a participant is connected from,
+// including ones that don't currently have this conversation open (e.g. the
+// conversation list). getParticipantsOfConversation also verifies the actor
+// is actually a member of conversation_id, rejecting spoofed ids.
+const registerTypingHandlers = (io, socket) => {
+  socket.on("typing", async ({ conversation_id }) => {
+    try {
+      const { id: user_id } = socket.data.user;
+      const participants = await conversationService.getParticipantsOfConversation(
+        conversation_id,
+        user_id
+      );
+
+      participants.forEach((p) => {
+        io.to(`user_${p.id}`).emit("user_typing", { conversation_id, user_id });
+      });
+    } catch (error) {
+      socket.emit("error", { message: error.message });
+    }
   });
 
-  socket.on("stop_typing", ({ conversation_id }) => {
-    const { id: user_id } = socket.data.user;
+  socket.on("stop_typing", async ({ conversation_id }) => {
+    try {
+      const { id: user_id } = socket.data.user;
+      const participants = await conversationService.getParticipantsOfConversation(
+        conversation_id,
+        user_id
+      );
 
-    socket
-      .to(`conversation_${conversation_id}`)
-      .emit("user_stopped_typing", { conversation_id, user_id });
+      participants.forEach((p) => {
+        io.to(`user_${p.id}`).emit("user_stopped_typing", { conversation_id, user_id });
+      });
+    } catch (error) {
+      socket.emit("error", { message: error.message });
+    }
   });
 };
 


### PR DESCRIPTION
## Summary
- **Security fix**: `typing`/`stop_typing` previously broadcast to whatever conversation room the client claimed, with no check that the sender actually belongs to that conversation (IDOR). Now relayed via `getParticipantsOfConversation`, which verifies membership and broadcasts to each participant's personal room instead — this also means status reaches every device a participant is on, not just whichever conversation they have open.
- Typing state moved from `useChat` (scoped to the open conversation) up to `useSocket` as a global `conversationId -> user ids` map, so it can power both the open chat view and the conversation list.
- Conversation list (`nav-conversation-item.jsx`) now shows "X is typing..." / "Someone is typing..." in place of the last-message preview.
- Chat view: replaced the plain text line under the conversation title with a Messenger-style animated bubble (avatar + bouncing dots) appended to the bottom of the message list via `motion/react` (already a dependency), fading/sliding in and out the same way a real message would appear.

## Test plan
- [x] `yarn build` passes
- [x] `node --check` on all server files passes
- [ ] Manually verify with two accounts: typing bubble appears/disappears smoothly in both direct and group chats, and the list preview updates for conversations not currently open