### PR TITLE
feat(chat): handle multiple simultaneous typists

### DIFF
--- a/client/src/components/chat/nav-conversation-item.jsx
+++ b/client/src/components/chat/nav-conversation-item.jsx
@@ -15,9 +15,11 @@ export default function NavConversationItem({ conversation }) {
   const selected = conversation.id === selectedConversationId;
 
   // No message history is loaded for conversations other than the open one,
-  // so group-chat typists can't be resolved to a name here (unlike the chat
+  // so group-chat typists can't be resolved to names here (unlike the chat
   // header) — only direct conversations can, via their already-known title.
-  const isTyping = (typingByConversation[conversation.id] ?? []).some((id) => id !== user?.id);
+  const typistCount = (typingByConversation[conversation.id] ?? []).filter(
+    (id) => id !== user?.id
+  ).length;
 
   return (
     <li
@@ -82,9 +84,13 @@ export default function NavConversationItem({ conversation }) {
             </Badge>
           )}
         </div>
-        {isTyping ? (
+        {typistCount > 0 ? (
           <p className="text-left text-xs text-blue-green italic animate-pulse truncate">
-            {conversation.type === "direct" ? `${conversation.title} is typing...` : "Someone is typing..."}
+            {conversation.type === "direct"
+              ? `${conversation.title} is typing...`
+              : typistCount === 1
+              ? "Someone is typing..."
+              : `${typistCount} people are typing...`}
           </p>
         ) : (
           <p

--- a/client/src/components/chat/typing-bubble.jsx
+++ b/client/src/components/chat/typing-bubble.jsx
@@ -3,7 +3,10 @@
 import { AnimatePresence, motion } from "motion/react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { AvatarGroup } from "@/components/ui/avatar-group";
 import { getInitials, pickAvatarColor } from "@/lib/user-utils";
+
+const MAX_AVATARS = 3;
 
 function TypingDots() {
   return (
@@ -20,29 +23,57 @@ function TypingDots() {
   );
 }
 
+// One avatar reads as "this person sent a message"; several typists still
+// share a single dots bubble (there's only one "conversation is live" state
+// to show), but stack their avatars and spell out who so it isn't ambiguous.
+function typingLabel(typists) {
+  const names = typists.map((t) => t.full_name);
+  if (names.length === 1) return null;
+  if (names.length === 2) return `${names[0]} and ${names[1]} are typing...`;
+  return `${names[0]}, ${names[1]} and ${names.length - 2} other${names.length - 2 > 1 ? "s" : ""} are typing...`;
+}
+
 export default function TypingBubble({ typists }) {
-  const typing = typists[0];
+  const label = typingLabel(typists);
 
   return (
     <AnimatePresence>
-      {typing && (
+      {typists.length > 0 && (
         <motion.div
-          key={typing.id}
+          key="typing-bubble"
           initial={{ opacity: 0, y: 12 }}
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: 12 }}
           transition={{ duration: 0.25, ease: "easeOut" }}
-          className="flex justify-start items-end gap-x-3 mt-4"
+          className="flex flex-col items-start gap-y-1 mt-4"
         >
-          <Avatar className="h-8 w-8 flex-none">
-            <AvatarImage src={typing.avatar_url} alt={typing.full_name} className="object-cover" />
-            <AvatarFallback className="text-sm" style={pickAvatarColor(typing.full_name)}>
-              {getInitials(typing.full_name)}
-            </AvatarFallback>
-          </Avatar>
-          <div className="flex items-center px-4 py-3 rounded-2xl rounded-bl-none bg-gray-200">
-            <TypingDots />
+          <div className="flex items-end gap-x-3">
+            <AvatarGroup className="flex items-center -space-x-2.5">
+              {typists.slice(0, MAX_AVATARS).map((typist) => (
+                <Avatar key={typist.id} className="h-8 w-8 text-xs ring-2 ring-ghost-white">
+                  <AvatarImage
+                    src={typist.avatar_url}
+                    alt={typist.full_name}
+                    className="object-cover"
+                  />
+                  <AvatarFallback className="text-sm" style={pickAvatarColor(typist.full_name)}>
+                    {getInitials(typist.full_name)}
+                  </AvatarFallback>
+                </Avatar>
+              ))}
+              {typists.length > MAX_AVATARS && (
+                <Avatar className="h-8 w-8 ring-2 ring-ghost-white">
+                  <AvatarFallback className="text-xs font-medium bg-blue-100 text-prussian-blue">
+                    +{typists.length - MAX_AVATARS}
+                  </AvatarFallback>
+                </Avatar>
+              )}
+            </AvatarGroup>
+            <div className="flex items-center px-4 py-3 rounded-2xl rounded-bl-none bg-gray-200">
+              <TypingDots />
+            </div>
           </div>
+          {label && <p className="text-xs text-gray-500 pl-1 truncate max-w-xs">{label}</p>}
         </motion.div>
       )}
     </AnimatePresence>


### PR DESCRIPTION
## Summary
- The typing bubble previously only ever showed the first typist and silently dropped anyone else typing at the same time.
- Now stacks up to 3 overlapping avatars (reusing the existing `AvatarGroup` pattern from task assignees) with a `+N` overflow badge, and adds a "A, B and N others are typing..." label once more than one person is active.
- Conversation list: counts typists per conversation instead of collapsing any group chat with 2+ people typing to a generic "Someone is typing...".

## Test plan
- [x] `yarn build` passes
- [ ] Manually verify with 3 accounts typing in the same group chat: avatars stack correctly, label text is accurate, and it collapses back to nothing once everyone stops