### PR TITLE
fix(style): actually make page backgrounds pure white

### DIFF
--- a/client/src/app/(app)/app/message/[id]/page.jsx
+++ b/client/src/app/(app)/app/message/[id]/page.jsx
@@ -3,7 +3,7 @@ import ChatHeader from "@/components/chat/chat-header";
 
 export default function ChatPage() {
   return (
-    <div className="flex flex-col items-center h-full bg-ghost-white">
+    <div className="flex flex-col items-center h-full bg-white">
       <ChatHeader />
       <ChatWindow />
     </div>

--- a/client/src/app/(app)/app/message/page.jsx
+++ b/client/src/app/(app)/app/message/page.jsx
@@ -3,7 +3,7 @@ import ChatHeader from "@/components/chat/chat-header";
 
 export default function ChatPage() {
   return (
-    <div className="flex flex-col items-center h-full bg-ghost-white">
+    <div className="flex flex-col items-center h-full bg-white">
       <ChatHeader />
       <ChatWindow />
     </div>

--- a/client/src/app/(app)/app/page.jsx
+++ b/client/src/app/(app)/app/page.jsx
@@ -13,7 +13,7 @@ export default function DashboardPage() {
       <AppHeader name="Dashboard">
         <DashboardHeader />
       </AppHeader>
-      <div className="flex-1 flex flex-col rounded-md bg-ghost-white overflow-auto">
+      <div className="flex-1 flex flex-col rounded-md bg-white overflow-auto">
         <DashboardWindow />
       </div>
     </div>

--- a/client/src/app/(auth)/auth/forgot-password/page.jsx
+++ b/client/src/app/(auth)/auth/forgot-password/page.jsx
@@ -21,7 +21,7 @@ export default function ForgotPasswordPage() {
           className="h-full w-full rounded-r-xl object-cover"
         />
       </div>
-      <div className="flex-1 max-w-[500px] p-12 bg-ghost-white flex flex-col justify-center ">
+      <div className="flex-1 max-w-[500px] p-12 bg-white flex flex-col justify-center ">
         <Suspense fallback={null}>
           <ForgotPasswordForm />
         </Suspense>

--- a/client/src/app/(auth)/auth/login/page.jsx
+++ b/client/src/app/(auth)/auth/login/page.jsx
@@ -21,7 +21,7 @@ export default function LoginPage() {
           className="h-full w-full rounded-r-xl object-cover"
         />
       </div>
-      <div className="flex-1 max-w-[500px] p-12 bg-ghost-white flex flex-col justify-center ">
+      <div className="flex-1 max-w-[500px] p-12 bg-white flex flex-col justify-center ">
         <Suspense fallback={null}>
           <LoginForm />
         </Suspense>

--- a/client/src/app/(auth)/auth/register/page.jsx
+++ b/client/src/app/(auth)/auth/register/page.jsx
@@ -20,7 +20,7 @@ export default function RegisterPage() {
           className="h-full w-full rounded-r-xl object-cover"
         />
       </div>
-      <div className="flex-1 max-w-[500px] p-12 bg-ghost-white flex flex-col justify-center">
+      <div className="flex-1 max-w-[500px] p-12 bg-white flex flex-col justify-center">
         <RegisterForm />
       </div>
     </div>

--- a/client/src/app/(auth)/auth/verify/page.jsx
+++ b/client/src/app/(auth)/auth/verify/page.jsx
@@ -20,7 +20,7 @@ export default function VerifyPage() {
           className="h-full w-full rounded-r-xl object-cover"
         />
       </div>
-      <div className="flex-1 max-w-[500px] p-12 bg-ghost-white flex flex-col justify-center ">
+      <div className="flex-1 max-w-[500px] p-12 bg-white flex flex-col justify-center ">
         <VerifyEmailForm />
       </div>
     </div>

--- a/client/src/components/chat/chat-window.jsx
+++ b/client/src/components/chat/chat-window.jsx
@@ -74,7 +74,7 @@ export default function ChatWindow() {
   }
 
   return (
-    <div className="relative flex-1 flex flex-col w-full overflow-hidden bg-ghost-white">
+    <div className="relative flex-1 flex flex-col w-full overflow-hidden bg-white">
       {loading ? (
         <div className="flex-1 flex w-full">
           <Spinner size="lg" className="-translate-y-16" />

--- a/client/src/components/chat/nav-conversation.jsx
+++ b/client/src/components/chat/nav-conversation.jsx
@@ -22,7 +22,7 @@ export default function NavConversation() {
   );
 
   return (
-    <Card className="h-full p-0 rounded-none bg-ghost-white overflow-hidden">
+    <Card className="h-full p-0 rounded-none overflow-hidden">
       <CardContent className="p-0 h-full">
         <Tabs defaultValue="all" className="h-full">
           <TabsList className="justify-start w-full px-6 gap-x-6 rounded-none border-b bg-white">

--- a/client/src/components/chat/typing-bubble.jsx
+++ b/client/src/components/chat/typing-bubble.jsx
@@ -50,7 +50,7 @@ export default function TypingBubble({ typists }) {
           <div className="flex items-end gap-x-3">
             <AvatarGroup className="flex items-center -space-x-2.5">
               {typists.slice(0, MAX_AVATARS).map((typist) => (
-                <Avatar key={typist.id} className="h-8 w-8 text-xs ring-2 ring-ghost-white">
+                <Avatar key={typist.id} className="h-8 w-8 text-xs ring-2 ring-white">
                   <AvatarImage
                     src={typist.avatar_url}
                     alt={typist.full_name}
@@ -62,7 +62,7 @@ export default function TypingBubble({ typists }) {
                 </Avatar>
               ))}
               {typists.length > MAX_AVATARS && (
-                <Avatar className="h-8 w-8 ring-2 ring-ghost-white">
+                <Avatar className="h-8 w-8 ring-2 ring-white">
                   <AvatarFallback className="text-xs font-medium bg-blue-100 text-prussian-blue">
                     +{typists.length - MAX_AVATARS}
                   </AvatarFallback>


### PR DESCRIPTION
## Summary
A previous PR changed the `--background` CSS token to pure white, but that token is only referenced by shadcn primitives (dialog, sheet, sidebar, tabs, etc.) — every actual page/feature-area wrapper hardcodes the literal `bg-ghost-white` utility class instead, so the earlier fix had no visible effect on real pages. This PR fixes the actual instances:

- Dashboard content wrapper (`app/page.jsx`)
- Chat pages + `chat-window.jsx` + `nav-conversation.jsx` (conversation list card)
- All 4 auth pages' form panel
- `typing-bubble.jsx`'s avatar ring color updated to match chat's new white background

Left untouched (deliberate, not part of this bug):
- The landing page's Testimonials section, which uses ghost-white intentionally as an alternating section background against surrounding white sections.
- The `--color-ghost-white` token itself, since it's also used as `--sidebar-foreground` (sidebar text color) — unrelated to page backgrounds.

Note: a further batch of `bg-ghost-white` usages exist in admin/team/task table wrapper cards and table header-row tints — holding off on those pending user input since some may be intentional (header/body row distinction).

## Test plan
- [x] `yarn build` passes