### PR TITLE
fix(team): sort join requests newest-first by default

### DIFF
--- a/server/src/api/models/team-model.js
+++ b/server/src/api/models/team-model.js
@@ -246,7 +246,8 @@ const getManyTeamJoinRequestsOfTeam = async (team_id) => {
         "v.email AS requester_email",
         "v.avatar_url AS requester_avatar_url"
       )
-      .where({ team_id });
+      .where({ team_id })
+      .orderBy("tjr.created_at", "desc");
 
     return requests;
   } catch (err) {


### PR DESCRIPTION
## Summary
- The team Invitations tab's join-request table had no default sort — `getManyTeamJoinRequestsOfTeam` (server/src/api/models/team-model.js) had no `ORDER BY`, and the client table's initial sort state is empty (it only sorts on explicit column-header clicks), so rows rendered in arbitrary DB order.
- Added `.orderBy("tjr.created_at", "desc")` so the newest requests show first by default.

## Test plan
- [x] `node --check` on all server files passes