### PR TITLE
feat(chat): @mention with notifications

### DIFF
--- a/client/src/components/chat/chat-input.jsx
+++ b/client/src/components/chat/chat-input.jsx
@@ -6,12 +6,21 @@ import { Send } from "lucide-react";
 
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
+import MentionPicker from "@/components/chat/mention-picker";
 import { useChat } from "@/hooks/use-chat";
+import { useSession } from "@/hooks/use-session";
+
+const MAX_MENTION_RESULTS = 6;
 
 export default function ChatInput() {
   const [message, setMessage] = useState("");
+  const [mentionedUsers, setMentionedUsers] = useState([]);
+  const [mentionQuery, setMentionQuery] = useState(null);
+  const [mentionStart, setMentionStart] = useState(null);
+  const [activeMentionIndex, setActiveMentionIndex] = useState(0);
   const textareaRef = useRef(null);
-  const { sendMessage, sendTyping, stopTyping } = useChat();
+  const { sendMessage, sendTyping, stopTyping, participants } = useChat();
+  const { user } = useSession();
 
   // Re-announce "typing" at most once every 2s while the user keeps typing
   // (leading-edge only), and announce "stopped typing" 2s after they pause.
@@ -29,14 +38,43 @@ export default function ChatInput() {
     };
   }, []);
 
+  const mentionCandidates =
+    mentionQuery === null
+      ? []
+      : participants
+          .filter((p) => p.id !== user?.id)
+          .filter((p) => p.full_name.toLowerCase().includes(mentionQuery.toLowerCase()))
+          .slice(0, MAX_MENTION_RESULTS);
+
+  const mentionPickerOpen = mentionQuery !== null && mentionCandidates.length > 0;
+
+  // Detects an in-progress "@query" right before the caret — the "@" must
+  // start a word (start of message or preceded by whitespace) and nothing
+  // after it may contain whitespace yet, otherwise the mention is "closed".
+  const detectMentionTrigger = (value, caretPos) => {
+    const textBeforeCaret = value.slice(0, caretPos);
+    const atIndex = textBeforeCaret.lastIndexOf("@");
+
+    if (atIndex === -1) return null;
+
+    const precedingChar = textBeforeCaret[atIndex - 1];
+    const isWordStart = atIndex === 0 || /\s/.test(precedingChar);
+    const query = textBeforeCaret.slice(atIndex + 1);
+
+    if (!isWordStart || /\s/.test(query)) return null;
+
+    return { atIndex, query };
+  };
+
   const handleChange = (e) => {
-    setMessage(e.target.value);
+    const value = e.target.value;
+    setMessage(value);
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
       textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
     }
 
-    if (e.target.value.trim()) {
+    if (value.trim()) {
       throttledSendTyping();
       debouncedStopTyping();
     } else {
@@ -44,6 +82,35 @@ export default function ChatInput() {
       debouncedStopTyping.cancel();
       stopTyping();
     }
+
+    const trigger = detectMentionTrigger(value, e.target.selectionStart);
+    if (trigger) {
+      setMentionStart(trigger.atIndex);
+      setMentionQuery(trigger.query);
+      setActiveMentionIndex(0);
+    } else {
+      setMentionQuery(null);
+    }
+  };
+
+  const selectMention = (participant) => {
+    const before = message.slice(0, mentionStart);
+    const after = message.slice(mentionStart + 1 + mentionQuery.length);
+    const insertion = `@${participant.full_name} `;
+
+    setMessage(`${before}${insertion}${after}`);
+    setMentionedUsers((prev) =>
+      prev.some((u) => u.id === participant.id) ? prev : [...prev, participant]
+    );
+    setMentionQuery(null);
+
+    requestAnimationFrame(() => {
+      if (textareaRef.current) {
+        const pos = before.length + insertion.length;
+        textareaRef.current.focus();
+        textareaRef.current.setSelectionRange(pos, pos);
+      }
+    });
   };
 
   const submitMessage = () => {
@@ -52,14 +119,42 @@ export default function ChatInput() {
     throttledSendTyping.cancel();
     debouncedStopTyping.cancel();
     stopTyping();
-    sendMessage(text);
+    sendMessage(
+      text,
+      mentionedUsers.map((u) => u.id)
+    );
     setMessage("");
+    setMentionedUsers([]);
+    setMentionQuery(null);
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
     }
   };
 
   const handleKeyDown = (e) => {
+    if (mentionPickerOpen) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActiveMentionIndex((i) => (i + 1) % mentionCandidates.length);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveMentionIndex((i) => (i - 1 + mentionCandidates.length) % mentionCandidates.length);
+        return;
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        selectMention(mentionCandidates[activeMentionIndex]);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setMentionQuery(null);
+        return;
+      }
+    }
+
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       submitMessage();
@@ -72,14 +167,22 @@ export default function ChatInput() {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="w-full px-4">
+    <form onSubmit={handleSubmit} className="relative w-full px-4">
+      {mentionPickerOpen && (
+        <MentionPicker
+          participants={mentionCandidates}
+          activeIndex={activeMentionIndex}
+          onSelect={selectMention}
+          onHoverIndex={setActiveMentionIndex}
+        />
+      )}
       <div className="flex flex-col items-end px-1 bg-white border-1 rounded-md overflow-hidden">
         <Textarea
           ref={textareaRef}
           value={message}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
-          placeholder="Type your message..."
+          placeholder="Type your message... use @ to mention someone"
           className="flex-1 bg-transparent resize-none overflow-auto max-h-40 p-4 placeholder-gray-400 border-none shadow-none focus-visible:ring-0 focus-visible:border-b-2 focus-visible:border-prussian-blue "
           style={{ minHeight: "2rem" }}
         />

--- a/client/src/components/chat/mention-picker.jsx
+++ b/client/src/components/chat/mention-picker.jsx
@@ -1,0 +1,42 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { getInitials, pickAvatarColor } from "@/lib/user-utils";
+import { cn } from "@/lib/utils";
+
+export default function MentionPicker({ participants, activeIndex, onSelect, onHoverIndex }) {
+  if (!participants.length) {
+    return null;
+  }
+
+  return (
+    <div className="absolute bottom-full left-4 mb-2 w-64 max-h-56 overflow-y-auto rounded-md border bg-white shadow-md z-10">
+      {participants.map((participant, idx) => (
+        <div
+          key={participant.id}
+          // Mousedown (not click) fires before the textarea's blur, so
+          // selecting a mention doesn't first collapse the caret position.
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onSelect(participant);
+          }}
+          onMouseEnter={() => onHoverIndex(idx)}
+          className={cn(
+            "flex items-center gap-2 px-3 py-2 cursor-pointer",
+            idx === activeIndex ? "bg-prussian-blue/10" : "hover:bg-prussian-blue/5"
+          )}
+        >
+          <Avatar className="h-6 w-6 flex-none text-xs">
+            <AvatarImage
+              src={participant.avatar_url}
+              alt={participant.full_name}
+              className="object-cover"
+            />
+            <AvatarFallback style={pickAvatarColor(participant.full_name)}>
+              {getInitials(participant.full_name)}
+            </AvatarFallback>
+          </Avatar>
+          <span className="text-sm truncate">{participant.full_name}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/chat/message-bubble.jsx
+++ b/client/src/components/chat/message-bubble.jsx
@@ -17,7 +17,8 @@ function messageBubbleStyle(curIdx, msgGroupLength, isMe) {
 }
 
 export default function MessageBubble({ msgGroup, isMe }) {
-  const { highlightId } = useChat();
+  const { highlightId, participants } = useChat();
+  const mentionNames = participants.map((p) => p.full_name);
 
   return (
     <div className={cn("flex justify-start gap-x-3 my-4", isMe ? "flex-row-reverse" : "flex-row")}>
@@ -54,7 +55,7 @@ export default function MessageBubble({ msgGroup, isMe }) {
                 )}
               >
                 <p className="text-sm leading-relaxed whitespace-pre-wrap">
-                  {linkifyMessage(msg.content)}
+                  {linkifyMessage(msg.content, mentionNames)}
                 </p>
               </div>
               <span

--- a/client/src/components/notification/notification-list.jsx
+++ b/client/src/components/notification/notification-list.jsx
@@ -1,4 +1,4 @@
-import { Users, FolderKanban, SquareCheckBig } from "lucide-react";
+import { Users, FolderKanban, SquareCheckBig, AtSign } from "lucide-react";
 
 import { useNotification } from "@/hooks/use-notification";
 import { cn, formatTimestampHour } from "@/lib/utils";
@@ -34,12 +34,14 @@ export default function NotificationList({ group }) {
                 "p-3 rounded-md",
                 notification.reference_type === "team" && "bg-blue-green text-white",
                 notification.reference_type === "project" && "bg-prussian-blue text-white",
-                notification.reference_type === "task" && "bg-mustard text-prussian-blue"
+                notification.reference_type === "task" && "bg-mustard text-prussian-blue",
+                notification.reference_type === "message" && "bg-sky-blue text-prussian-blue"
               )}
             >
               {notification.reference_type === "team" && <Users className="w-5 h-5" />}
               {notification.reference_type === "project" && <FolderKanban className="w-5 h-5" />}
               {notification.reference_type === "task" && <SquareCheckBig className="w-5 h-5" />}
+              {notification.reference_type === "message" && <AtSign className="w-5 h-5" />}
             </div>
             <div className="space-y-1">
               <p className="text-sm font-medium truncate">{notification.title}</p>

--- a/client/src/hooks/use-chat.js
+++ b/client/src/hooks/use-chat.js
@@ -4,7 +4,7 @@ import { createContext, useContext, useState, useEffect, useCallback, useRef } f
 import { useRouter, usePathname } from "next/navigation";
 import { useSession } from "@/hooks/use-session";
 import { useSocket } from "@/hooks/use-socket";
-import { getConversations } from "@/actions/conversation-actions";
+import { getConversations, getParticipantsOfConversation } from "@/actions/conversation-actions";
 import { getMessagesOfConversation } from "@/actions/message-actions";
 
 const ChatContext = createContext();
@@ -22,6 +22,7 @@ export function ChatProvider({ children }) {
   const [conversations, setConversations] = useState([]);
   const [selectedConversationId, setSelectedConversationId] = useState(null);
   const [messages, setMessages] = useState([]);
+  const [participants, setParticipants] = useState([]);
   const [lastReadMessageId, setLastReadMessageId] = useState(null);
   const [highlightId, setHighlightId] = useState(null);
   const [scrollTargetId, setScrollTargetId] = useState(null);
@@ -109,6 +110,7 @@ export function ChatProvider({ children }) {
     socket.on("new_message", handleNewMsg);
 
     setLoading(true);
+    setParticipants([]);
 
     getMessagesOfConversation(selectedConversationId)
       .then((data) => {
@@ -116,6 +118,13 @@ export function ChatProvider({ children }) {
       })
       .catch((err) => setError(err))
       .finally(() => setLoading(false));
+
+    // Used for the @mention picker and for highlighting mentions in
+    // messages — not part of the initial page load path, so failures here
+    // shouldn't surface as a conversation-level error.
+    getParticipantsOfConversation(selectedConversationId)
+      .then((data) => setParticipants(data.participants))
+      .catch(() => {});
 
     return () => {
       socket.off("update_conversation", handleUpdateConv);
@@ -140,11 +149,15 @@ export function ChatProvider({ children }) {
   );
 
   const sendMessage = useCallback(
-    (content) => {
+    (content, mentionedUserIds = []) => {
       const trimmed = content.trim();
       const cid = selectedIdRef.current;
       if (!socketConnected || !cid || !trimmed) return;
-      socket.emit("send_message", { conversation_id: cid, content: trimmed });
+      socket.emit("send_message", {
+        conversation_id: cid,
+        content: trimmed,
+        mentioned_user_ids: [...new Set(mentionedUserIds)]
+      });
     },
     [socket, socketConnected]
   );
@@ -168,6 +181,7 @@ export function ChatProvider({ children }) {
         selectedConversationId,
         changeConversation,
         messages,
+        participants,
         lastReadMessageId,
         sendMessage,
         typingUserIds,

--- a/client/src/hooks/use-notification.js
+++ b/client/src/hooks/use-notification.js
@@ -33,7 +33,8 @@ export function NotificationProvider({ children }) {
     { value: "all", label: "All Notifications" },
     { value: "team", label: "Team Notifications" },
     { value: "project", label: "Project Notifications" },
-    { value: "task", label: "Task Notifications" }
+    { value: "task", label: "Task Notifications" },
+    { value: "message", label: "Mention Notifications" }
   ];
 
   // Fetch notifications

--- a/client/src/lib/chat-utils.js
+++ b/client/src/lib/chat-utils.js
@@ -67,22 +67,48 @@ export function getTypingParticipants(conversation, typingUserIds, messages, cur
   }));
 }
 
-export function linkifyMessage(message) {
-  const urlRegex = /(https?:\/\/[\w.-]+(?:\/[\w\-._~:\/?#[\]@!$&'()*+,;=]*)?)/g;
-  return message.split(urlRegex).map((part, idx) => {
-    if (urlRegex.test(part)) {
-      return (
-        <Link
-          key={idx}
-          href={part}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-blue-green hover:underline"
-        >
-          {part}
-        </Link>
-      );
-    }
-    return <span key={idx}>{part}</span>;
-  });
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Highlights "@Full Name" mentions alongside the existing URL linkification.
+// Matches against known participant names (rather than any "@word") so a
+// message that merely contains a literal "@" isn't mistaken for a mention.
+// A lookahead (not \b) ends the match, since \b is ASCII-word-boundary only
+// and misbehaves right after names with diacritics (e.g. Vietnamese names).
+export function linkifyMessage(message, mentionNames = []) {
+  const urlPattern = "(https?://[\\w.-]+(?:/[\\w\\-._~:/?#[\\]@!$&'()*+,;=]*)?)";
+  const sortedNames = [...mentionNames].sort((a, b) => b.length - a.length);
+  const mentionPattern = sortedNames.length
+    ? `(@(?:${sortedNames.map(escapeRegExp).join("|")})(?=\\s|$|[.,!?;:]))`
+    : null;
+
+  const regex = new RegExp(mentionPattern ? `${urlPattern}|${mentionPattern}` : urlPattern, "g");
+
+  return message
+    .split(regex)
+    .filter((part) => part !== undefined)
+    .map((part, idx) => {
+      if (/^https?:\/\//.test(part)) {
+        return (
+          <Link
+            key={idx}
+            href={part}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-green hover:underline"
+          >
+            {part}
+          </Link>
+        );
+      }
+      if (part[0] === "@" && sortedNames.some((name) => part === `@${name}`)) {
+        return (
+          <span key={idx} className="text-blue-green font-medium bg-blue-green/10 rounded px-1">
+            {part}
+          </span>
+        );
+      }
+      return <span key={idx}>{part}</span>;
+    });
 }

--- a/server/src/api/services/message-service.js
+++ b/server/src/api/services/message-service.js
@@ -2,9 +2,13 @@ import { StatusCodes } from "http-status-codes";
 
 import messageModel from "../models/message-model.js";
 import conversationModel from "../models/conversation-model.js";
+import notificationModel from "../models/notification-model.js";
 import ApiError from "../../utils/api-error.js";
 import embeddingProvider from "../../config/embedding-provider.js";
+import { emitNewNotification } from "../../socket/notification-socket.js";
 import { sanitizeAllowedFields } from "../../utils/helper.js";
+
+const MENTION_PREVIEW_LENGTH = 120;
 
 const createOneMessage = async (data) => {
   try {
@@ -79,8 +83,38 @@ const updateOneMessageById = async (id, data, actorId) => {
   }
 };
 
+const notifyMentionedUsers = async (message, mentionedUserIds) => {
+  try {
+    const { conversation_id, sender_id, sender_full_name, content } = message;
+
+    const preview =
+      content.length > MENTION_PREVIEW_LENGTH
+        ? `${content.slice(0, MENTION_PREVIEW_LENGTH)}...`
+        : content;
+
+    const recipients = [...new Set(mentionedUserIds)].filter((id) => id !== sender_id);
+
+    for (const userId of recipients) {
+      const notificationId = await notificationModel.createOneNotification({
+        user_id: userId,
+        reference_type: "message",
+        reference_id: conversation_id,
+        title: "New mention",
+        content: `<@${sender_full_name}> mentioned you: "${preview}"`
+      });
+
+      const notification = await notificationModel.getOneNotificationById(notificationId);
+
+      emitNewNotification(userId, notification);
+    }
+  } catch (err) {
+    throw err;
+  }
+};
+
 export default {
   createOneMessage,
   getManyMessagesByConversationId,
-  updateOneMessageById
+  updateOneMessageById,
+  notifyMentionedUsers
 };

--- a/server/src/config/database.example.sql
+++ b/server/src/config/database.example.sql
@@ -187,7 +187,7 @@ CREATE TABLE IF NOT EXISTS notifications (
   user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   title VARCHAR(255) NOT NULL,
   content TEXT NOT NULL,
-  reference_type VARCHAR(30) NOT NULL CHECK (reference_type IN ('team','project','task')),
+  reference_type VARCHAR(30) NOT NULL CHECK (reference_type IN ('team','project','task','message')),
   reference_id INT,
   is_read BOOLEAN DEFAULT FALSE,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP

--- a/server/src/socket/message-socket.js
+++ b/server/src/socket/message-socket.js
@@ -2,7 +2,7 @@ import conversationService from "../api/services/conversation-service.js";
 import messageService from "../api/services/message-service.js";
 
 const registerMessageHandlers = (io, socket) => {
-  socket.on("send_message", async ({ conversation_id, content }) => {
+  socket.on("send_message", async ({ conversation_id, content, mentioned_user_ids = [] }) => {
     try {
       const { id: sender_id } = socket.data.user;
 
@@ -59,6 +59,19 @@ const registerMessageHandlers = (io, socket) => {
           io.to(`user_${p.id}`).emit("update_conversation", conversation);
         })
       );
+
+      if (mentioned_user_ids.length) {
+        // Only notify ids that are actually participants of this
+        // conversation — the mention list comes from the client, so this
+        // guards against a spoofed/stale id being used to notify someone
+        // who was never in this chat.
+        const participantIds = new Set(participants.map((p) => p.id));
+        const validMentions = mentioned_user_ids.filter((id) => participantIds.has(id));
+
+        if (validMentions.length) {
+          await messageService.notifyMentionedUsers(message, validMentions);
+        }
+      }
     } catch (error) {
       socket.emit("error", { message: error.message });
     }


### PR DESCRIPTION
## Summary
- Typing "@" in the chat input opens a picker (arrow keys + Enter/Tab to select, Escape to close) filtered to the open conversation's participants — wired up the previously-unused `getParticipantsOfConversation` endpoint via `useChat()`.
- Selected mentions are tracked client-side and sent alongside the message (`mentioned_user_ids`); the server re-validates each id is an actual conversation participant (defends against a spoofed id) before creating a notification and delivering it over the same per-user socket room used for other notifications.
- Rendered messages highlight `@Full Name` by matching known participant names specifically (not just any `@word`), extending the existing URL-linkify pass.
- Widened `notifications.reference_type` CHECK constraint to add `'message'` — applied directly to the production DB (approved by user) and updated in the example schema doc.

**Known scope limitation**: only mentions inserted via the picker trigger a notification — free-typing "@Full Name" without picking from the dropdown won't notify (avoids ambiguous name-matching, e.g. duplicate names). This matches how most mention implementations handle it.

## Test plan
- [x] `yarn build` passes
- [x] `node --check` on all server files passes
- [x] Production DB constraint verified updated (`\d notifications` shows `'message'` in the CHECK)
- [ ] Manually verify: typing `@` shows the picker, selecting inserts the name, sending notifies the mentioned user in real time