### PR TITLE
fix(server): copy public/ into the production Docker image

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -13,6 +13,7 @@ RUN yarn install --production --frozen-lockfile
 
 # Copy local directories to the current local directory of our docker image (/app)
 COPY ./src ./src
+COPY ./public ./public
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary
- Verify-email and password-reset were returning 500 in production. The Dockerfile only did `COPY ./src ./src`, so `public/templates/*.ejs` never made it into the built image — `ejs.renderFile` threw ENOENT for every outgoing mail (verification and password-reset), regardless of the Resend migration itself (confirmed Resend send/domain/key all work fine via a direct API test).
- Added `COPY ./public ./public` to the Dockerfile.

## Test plan
- [ ] After deploy, retry "Verify Email" / "Forgot Password" in production and confirm the OTP email arrives