### PR TITLE
style: shift primary blue toward ocean blue, revert health banner

### DIFF
--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -96,7 +96,7 @@
 }
 
 @theme {
-  --color-prussian-blue: #023047ff;
+  --color-prussian-blue: #021f47ff;
   --color-blue-green: #219ebcff;
   --color-sky-blue: #8ecae6ff;
   --color-mustard: #fdd161ff;

--- a/client/src/components/admin/admin-health-panel.jsx
+++ b/client/src/components/admin/admin-health-panel.jsx
@@ -66,7 +66,7 @@ export default function AdminHealthPanel() {
             "flex items-center justify-between gap-4 rounded-xl p-6 text-white",
             allHealthy
               ? "bg-prussian-blue"
-              : "bg-gradient-to-r from-blue-green from-0% via-blue-green via-65% to-red-900 to-100%"
+              : "bg-gradient-to-r from-prussian-blue from-0% via-prussian-blue via-65% to-red-900 to-100%"
           )}
         >
           <div>


### PR DESCRIPTION
## Summary
- Reverted the Health tab's status banner gradient back to the app's actual primary blue (`prussian-blue`) instead of the `blue-green` accent it was swapped to — that swap changed which color family was used, not what was asked.
- Adjusted `--color-prussian-blue` itself: same saturation/lightness, hue rotated ~15° away from teal/cyan toward blue (`#023047` → `#021f47`) for a more "ocean blue" look. Since this is a shared token, it cascades to every existing usage (sidebar, buttons, badges, headers) — not just the health banner.

## Test plan
- [x] `yarn build` passes