### PR TITLE
fix(auth): stop force-logging-out on avatar/profile update

### DIFF
--- a/client/src/hooks/use-account.js
+++ b/client/src/hooks/use-account.js
@@ -24,7 +24,7 @@ export function AccountProvider({ children }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const { refreshSession, logout } = useSession();
+  const { refetchSession, logout } = useSession();
 
   const fetchAccount = useCallback(async () => {
     try {
@@ -48,7 +48,7 @@ export function AccountProvider({ children }) {
         setAccount((prev) => ({ ...prev, ...data }));
 
         await updateMyProfile(data);
-        await refreshSession();
+        await refetchSession();
       } catch (err) {
         setError(err);
       }
@@ -69,7 +69,7 @@ export function AccountProvider({ children }) {
   const handleUploadAvatar = useCallback(async (file) => {
     try {
       const avatarData = await uploadMyAvatar(file);
-      await refreshSession();
+      await refetchSession();
 
       setAccount((prev) => ({ ...prev, avatar_url: avatarData.avatar_url }));
     } catch (err) {

--- a/client/src/hooks/use-session.js
+++ b/client/src/hooks/use-session.js
@@ -116,11 +116,26 @@ export function SessionProvider({ children }) {
     }
   }, [handleSession]);
 
+  // Re-reads the current user from the still-valid access token (GET
+  // /auth/me) — unlike refreshSession, this doesn't touch /auth/refresh, so
+  // it works regardless of whether "remember me" was checked at login. Use
+  // this after an update that changes the logged-in user's own data (e.g.
+  // profile/avatar) and just needs the cached session to reflect it.
+  const refetchSessionHandler = useCallback(async () => {
+    if (isRefreshingRef.current) return;
+    try {
+      await handleSession(false);
+    } catch (err) {
+      setError(err);
+    }
+  }, [handleSession]);
+
   const contextValue = {
     user,
     loading,
     error,
     refreshSession: refreshSessionHandler,
+    refetchSession: refetchSessionHandler,
     logout: logoutHandler
   };
 


### PR DESCRIPTION
## Summary
- Root cause of "changed my avatar and got kicked to login": `handleUpdateProfile`/`handleUploadAvatar` (`use-account.js`) unconditionally called `refreshSession()` afterward, which POSTs to `/auth/refresh` — that endpoint requires a `refresh_token` cookie, only set when "remember me" is checked at login. Without it, this always 401'd, and `use-session.js`'s failure path treats any refresh failure as a revoked session (clears it, redirects to `/auth/login`).
- Added `refetchSession()` in `use-session.js`, backed by `GET /auth/me` (only needs the still-valid access token, no refresh_token at all) — this is all that's actually needed to pick up a profile/avatar change into the cached session user object. Switched both callers to it.
- Left `query-provider.jsx`'s use of `refreshSession` untouched — that one reacts to a real 401 from an expired access token, where attempting an actual refresh is the correct behavior.

Confirmed via a DB check that this is unrelated to a recent direct `email_verified` update on one user's row — `token_version` (the only thing that can invalidate an existing refresh token) is untouched by that edit, and is only ever bumped by admin disable/force-logout actions.

**Separately noticed, not fixed here**: `client/src/routes.js`'s `PROTECTED_ROUTES` array is empty (both entries commented out), so the email-verification redirect gate in `middleware.js` is currently dead code — it doesn't block navigation to any route today. Flagging in case that was meant to be active; happy to open a follow-up if so.

## Test plan
- [x] `yarn build` passes
- [ ] Manually verify: log in **without** "remember me", change avatar/profile — should no longer be logged out