### PR TITLE
feat(chat): click a mention notification to jump to the message

### DIFF
--- a/client/src/actions/message-actions.js
+++ b/client/src/actions/message-actions.js
@@ -3,3 +3,7 @@ import { get } from "@/actions/fetch-client";
 export async function getMessagesOfConversation(conversationId) {
   return get(`/messages?conversation_id=${conversationId}`);
 }
+
+export async function getMessageById(messageId) {
+  return get(`/messages/${messageId}`);
+}

--- a/client/src/components/notification/notification-button.jsx
+++ b/client/src/components/notification/notification-button.jsx
@@ -13,12 +13,12 @@ import { cn } from "@/lib/utils";
 
 export default function NotificationButton() {
   const buttonRef = useRef(null);
-  const { unreadCount } = useNotification();
+  const { unreadCount, open, setOpen } = useNotification();
   const { open: sidebarOpen } = useSidebar();
 
   return (
     <div className="relative">
-      <Popover>
+      <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <SidebarMenuButton
             ref={buttonRef}

--- a/client/src/components/notification/notification-list.jsx
+++ b/client/src/components/notification/notification-list.jsx
@@ -1,6 +1,11 @@
+"use client";
+
+import { useRouter } from "next/navigation";
 import { Users, FolderKanban, SquareCheckBig, AtSign } from "lucide-react";
 
 import { useNotification } from "@/hooks/use-notification";
+import { useChat } from "@/hooks/use-chat";
+import { getMessageById } from "@/actions/message-actions";
 import { cn, formatTimestampHour } from "@/lib/utils";
 
 function highlightUser(content) {
@@ -11,7 +16,26 @@ function highlightUser(content) {
 }
 
 export default function NotificationList({ group }) {
-  const { markAsRead } = useNotification();
+  const { markAsRead, setOpen } = useNotification();
+  const { setScrollTargetId } = useChat();
+  const router = useRouter();
+
+  const handleClick = async (notification) => {
+    markAsRead(notification.id);
+
+    if (notification.reference_type === "message") {
+      try {
+        const { message } = await getMessageById(notification.reference_id);
+
+        router.push(`/app/message/${message.conversation_id}`);
+        setScrollTargetId(message.id);
+        setOpen(false);
+      } catch {
+        // The message (or the conversation it was in) may have been
+        // deleted since the notification was created — nothing to jump to.
+      }
+    }
+  };
 
   return (
     <div key={group.date} className="space-y-2 mb-2">
@@ -24,7 +48,7 @@ export default function NotificationList({ group }) {
           <div
             key={notification.id}
             className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 px-4 py-2 hover:bg-prussian-blue/10 transition duration-200 ease-in-out"
-            onClick={() => markAsRead(notification.id)}
+            onClick={() => handleClick(notification)}
             tabIndex={0}
             role="button"
             aria-label={`Mark as read: ${notification.title}`}

--- a/client/src/hooks/use-notification.js
+++ b/client/src/hooks/use-notification.js
@@ -18,6 +18,7 @@ export function useNotification() {
 }
 
 export function NotificationProvider({ children }) {
+  const [open, setOpen] = useState(false);
   const [notifications, setNotifications] = useState([]);
   const [unreadCount, setUnreadCount] = useState(0);
   const [filter, setFilter] = useState("all");
@@ -127,6 +128,8 @@ export function NotificationProvider({ children }) {
   }, [socket, socketConnected]);
 
   const contextValue = {
+    open,
+    setOpen,
     notifications,
     unreadCount,
     filterOptions,

--- a/server/src/api/controllers/message-controller.js
+++ b/server/src/api/controllers/message-controller.js
@@ -18,6 +18,20 @@ const getMessagesOfConversation = async (req, res, next) => {
   }
 };
 
+const getOneMessageById = async (req, res, next) => {
+  try {
+    const message = await messageService.getOneMessageById(req.params.id, req.user.id);
+
+    res.status(StatusCodes.OK).json({
+      success: true,
+      data: { message }
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
 export default {
-  getMessagesOfConversation
+  getMessagesOfConversation,
+  getOneMessageById
 };

--- a/server/src/api/routes/message-route.js
+++ b/server/src/api/routes/message-route.js
@@ -11,6 +11,8 @@ const messageRoute = (router) => {
       messageValidation.validateConversationIdQuery,
       messageController.getMessagesOfConversation
     );
+
+  router.route("/messages/:id").get(messageController.getOneMessageById);
 };
 
 export default messageRoute;

--- a/server/src/api/services/message-service.js
+++ b/server/src/api/services/message-service.js
@@ -56,6 +56,32 @@ const getManyMessagesByConversationId = async (conversationId, actorId) => {
   }
 };
 
+const getOneMessageById = async (id, actorId) => {
+  try {
+    const message = await messageModel.getOneMessageById(id);
+
+    if (!message) {
+      throw new ApiError(StatusCodes.NOT_FOUND, "Message not found");
+    }
+
+    const isConversationParticipant = await conversationModel.isUserInConversation(
+      message.conversation_id,
+      actorId
+    );
+
+    if (!isConversationParticipant) {
+      throw new ApiError(
+        StatusCodes.FORBIDDEN,
+        "Only participants of conversation can access this"
+      );
+    }
+
+    return message;
+  } catch (err) {
+    throw err;
+  }
+};
+
 const updateOneMessageById = async (id, data, actorId) => {
   try {
     const isMessageSender = await messageModel.isUserMessageSender(id, actorId);
@@ -85,7 +111,7 @@ const updateOneMessageById = async (id, data, actorId) => {
 
 const notifyMentionedUsers = async (message, mentionedUserIds) => {
   try {
-    const { conversation_id, sender_id, sender_full_name, content } = message;
+    const { id: message_id, sender_id, sender_full_name, content } = message;
 
     const preview =
       content.length > MENTION_PREVIEW_LENGTH
@@ -98,7 +124,7 @@ const notifyMentionedUsers = async (message, mentionedUserIds) => {
       const notificationId = await notificationModel.createOneNotification({
         user_id: userId,
         reference_type: "message",
-        reference_id: conversation_id,
+        reference_id: message_id,
         title: "New mention",
         content: `<@${sender_full_name}> mentioned you: "${preview}"`
       });
@@ -115,6 +141,7 @@ const notifyMentionedUsers = async (message, mentionedUserIds) => {
 export default {
   createOneMessage,
   getManyMessagesByConversationId,
+  getOneMessageById,
   updateOneMessageById,
   notifyMentionedUsers
 };


### PR DESCRIPTION
## Summary
- Clicking a "message"-type (mention) notification now navigates to the conversation and scrolls to/highlights the exact message — reuses the exact mechanism search results already use (`router.push` + `setScrollTargetId`, consumed by the existing scroll-and-highlight effect in `chat-window.jsx`).
- Mention notifications now store the **message id** as `reference_id` (previously the conversation id, which wasn't enough to locate a specific message). Added `GET /messages/:id` (participant-checked, like the existing message list endpoint) to resolve a message id back to its conversation id for navigation.
- Notification popover is now controlled (`open`/`setOpen` on `useNotification`) so it closes after navigating, matching the search dialog's existing behavior.

## Audit: is the existing search-to-message navigation solid?
Yes — traced end to end (`search-item-message.jsx` → `setScrollTargetId` → `use-chat.js`'s URL-matching + message-fetch effects → `chat-window.jsx`'s scroll-and-highlight effect gated on `!loading`). No pagination exists on message history (conversations always load in full), so the target message is always present once loaded — no race condition found. No changes made to this path; the mention feature above just reuses it as-is.

## Test plan
- [x] `yarn build` passes
- [x] `node --check` on all server files passes
- [ ] Manually verify: get mentioned by another account, click the notification, confirm it opens the right conversation scrolled to the right message